### PR TITLE
Say which side of the volume mount has to match the download client

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,18 @@ Three things worth knowing:
   `id -u` / `id -g` for your media user. Only `/config` is chowned — never the
   library or downloads volumes, because a recursive chown of a multi-terabyte
   share at every boot is not something an image should do to you.
-- **Mount the downloads volume at the path your download client reports.** If
-  qBittorrent says `/downloads/complete`, mount it there here too. Otherwise
-  the import looks for a finished file where it is not, and you get "download
-  path does not exist" while the file sits in plain sight. If matching the path
-  is impossible, set a mapping under Settings → Media Management instead.
+- **On the downloads volume, the container side is the one that has to match
+  your download client.** In `-v /mnt/downloads/complete:/downloads/complete`
+  the left side is wherever the files really live on the host, and the right
+  side has to be the path the client *reports* — Romarr asks the client where a
+  finished download is and then opens that path itself, so the two have to
+  agree. qBittorrent shows it as "Save path" under Options → Downloads, SABnzbd
+  as "Completed Download Folder" under Config → Folders. A client running on the
+  host rather than in a container reports host paths, which makes both sides
+  identical. Get this wrong and the import looks for a finished file where it is
+  not: you get "download path does not exist in this container" while the file
+  sits in plain sight. When the paths genuinely cannot be made to match, set a
+  mapping under Settings → Media Management instead.
 - **`/config` holds the decisions you make in the UI**, and a setting saved
   there outranks the environment from then on. That is deliberate — an
   environment default must not silently undo a choice — but it means changing
@@ -207,9 +214,12 @@ the settings file:
 ]
 ```
 
-The longest matching prefix wins. A mapping cannot help if the volume is not
-mounted here at all — that stays a mount problem, and you find out because the
-translated path still does not exist.
+The longest matching prefix wins, so a specific mapping overrides a broader one
+rather than depending on which was added first. A mapping cannot help if the
+volume is not mounted here at all — that stays a mount problem. Either way the
+log names both the path the client reported and what Romarr made of it, which is
+what tells the two apart: no mapping matched, or a mapping matched and its local
+side is wrong.
 
 Use a **dedicated RomM account**, not your admin one. Romarr needs only
 enough to trigger a scan.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,10 +68,30 @@ services:
 
       # Your download client's completed directory.
       #
-      # Mount it at the SAME path your download client reports, or Romarr looks
-      # for a finished download where it is not. If qBittorrent says
-      # /downloads/complete, mount it at /downloads/complete here. When that is
-      # impossible, set a mapping under Settings -> Media Management instead.
+      # Left side is the host. The RIGHT side must be the path your download
+      # client reports, character for character -- Romarr asks the client where
+      # a finished download is and then opens that path itself, so the two have
+      # to agree. The host side only has to be the directory actually holding
+      # those files; it does not have to resemble the container path.
+      #
+      # So if the files live at /mnt/downloads/complete on the host and SABnzbd
+      # reports /downloads/complete, both sides change:
+      #
+      #     - /mnt/downloads/complete:/downloads/complete
+      #
+      # A client running on the host rather than in a container reports host
+      # paths, which makes the two sides identical:
+      #
+      #     - /mnt/downloads:/mnt/downloads
+      #
+      # Not sure what your client reports? qBittorrent shows it as "Save path"
+      # in Options -> Downloads; SABnzbd as "Completed Download Folder" in
+      # Config -> Folders. Romarr uses whatever the client's API returns, which
+      # is that setting.
+      #
+      # When the paths genuinely cannot be made to match, leave this as-is and
+      # add a mapping under Settings -> Media Management, which rewrites the
+      # client's prefix into a local one.
       - /path/to/downloads:/downloads
 
 # Prefer an env file to editing this one? Delete the `environment:` block and

--- a/romarr/library.py
+++ b/romarr/library.py
@@ -69,7 +69,17 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
                overwrite: bool = False) -> ImportResult:
     """Place the ROM from a finished download into RomM's library."""
     if not download.exists():
-        return ImportResult(False, None, f"download path does not exist: {download}")
+        # Almost always a mount problem rather than a missing download: the
+        # client has the file and reported where IT sees it, and this process
+        # cannot see that path. "does not exist" on its own sends people looking
+        # for a lost download that is sitting right there, so say which of the
+        # two fixes applies.
+        return ImportResult(
+            False, None,
+            f"download path does not exist in this container: {download}. "
+            "Mount the download client's completed directory at that exact "
+            "path, or add a remote path mapping under Settings -> Media "
+            "Management.")
 
     candidates = list_candidates(download)
     chosen = pick_rom_file(candidates, platform)
@@ -121,7 +131,35 @@ def map_remote_path(path, mappings):
             if best is None or len(remote) > len(best[0]):
                 best = (remote, local)
     if best is None:
-        return Path(text)
+        return _checked(Path(text), text, mapped=False)
     remote, local = best
     rest = text[len(remote):].lstrip("/\\")
-    return Path(local) / rest if rest else Path(local)
+    return _checked(Path(local) / rest if rest else Path(local), text, mapped=True)
+
+
+def _checked(result: Path, reported: str, *, mapped: bool) -> Path:
+    """Warn, once translation is done, if the result is not openable here.
+
+    This is the only point that knows both paths, and the difference between
+    them is the whole diagnosis. Without it the operator sees a download that
+    completed and never imported, and nothing that names the container path
+    Romarr actually tried -- which is the one string that makes a wrong volume
+    mount obvious.
+
+    A warning rather than a raise: the caller reports the failure per download,
+    and one unopenable path must not stop the others importing.
+    """
+    if not reported or result.exists():
+        return result
+    if mapped:
+        log.warning(
+            "download client reported %s, which a remote path mapping turns "
+            "into %s -- and that does not exist here. Check the mapping's local "
+            "side against what is really mounted.", reported, result)
+    else:
+        log.warning(
+            "download client reported %s, which does not exist here and no "
+            "remote path mapping covers it. Mount the client's completed "
+            "directory at that exact path, or add a mapping under Settings -> "
+            "Media Management.", reported)
+    return result

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,9 +1,11 @@
+import logging
 import zipfile
+from pathlib import Path
 
 import pytest
 
 from romarr.indexers import Prowlarr, sanitise_for_display
-from romarr.library import import_rom, list_candidates, safe_members
+from romarr.library import import_rom, list_candidates, map_remote_path, safe_members
 from romarr.platforms import by_slug
 from romarr.selection import Release
 
@@ -106,6 +108,84 @@ def test_missing_download_is_reported_not_raised(tmp_path):
     result = import_rom(tmp_path / "nope.zip", SNES, tmp_path / "library")
     assert not result.ok
     assert "does not exist" in result.reason
+
+
+def test_a_missing_download_names_both_ways_to_fix_it(tmp_path):
+    """The overwhelmingly common cause is a wrong volume mount, not a lost
+    download. Reporting only "does not exist" sends people hunting for a file
+    that is sitting in their download client, so the reason has to name the
+    container path that was tried and both remedies."""
+    result = import_rom(tmp_path / "nope.zip", SNES, tmp_path / "library")
+    assert "in this container" in result.reason
+    assert str(tmp_path / "nope.zip") in result.reason
+    assert "Mount" in result.reason and "remote path mapping" in result.reason
+
+
+# --- remote path mapping -----------------------------------------------------
+#
+# The client reports paths in ITS filesystem. Getting this wrong is the single
+# most common Docker misconfiguration for this kind of app, and it presents as a
+# download that completes and then silently never appears.
+
+def test_an_unmapped_path_is_returned_unchanged():
+    assert map_remote_path("/downloads/complete/Game", []) \
+        == Path("/downloads/complete/Game")
+    assert map_remote_path("/downloads/x", None) == Path("/downloads/x")
+
+
+def test_a_mapping_rewrites_only_the_prefix():
+    mappings = [{"remote": "/downloads", "local": "/mnt/dl"}]
+    assert map_remote_path("/downloads/complete/Game.zip", mappings) \
+        == Path("/mnt/dl/complete/Game.zip")
+    # An exact match maps to the local root rather than appending an empty part.
+    assert map_remote_path("/downloads", mappings) == Path("/mnt/dl")
+
+
+def test_the_longest_matching_prefix_wins_regardless_of_order():
+    # Otherwise a broad mapping added first shadows the specific one that was
+    # added to correct it.
+    mappings = [
+        {"remote": "/downloads", "local": "/mnt/all"},
+        {"remote": "/downloads/complete", "local": "/mnt/done"},
+    ]
+    assert map_remote_path("/downloads/complete/G", mappings) == Path("/mnt/done/G")
+    assert map_remote_path("/downloads/incomplete/G", mappings) == Path("/mnt/all/incomplete/G")
+
+
+def test_incomplete_mapping_rows_are_ignored():
+    # A half-filled row in the settings UI must not swallow every path.
+    mappings = [{"remote": "/downloads", "local": ""}, {"remote": "", "local": "/mnt"}]
+    assert map_remote_path("/downloads/G", mappings) == Path("/downloads/G")
+
+
+def test_a_windows_style_remote_path_maps(tmp_path):
+    mappings = [{"remote": "D:\\torrents", "local": "/downloads"}]
+    assert map_remote_path("D:\\torrents\\Game", mappings) == Path("/downloads/Game")
+
+
+def test_an_unopenable_result_warns_and_names_both_paths(caplog):
+    """The warning is the only place both paths appear together, and the
+    difference between them is the entire diagnosis."""
+    with caplog.at_level(logging.WARNING):
+        map_remote_path("/downloads/complete/Game", [])
+    assert "/downloads/complete/Game" in caplog.text
+    assert "no remote path mapping covers it" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        map_remote_path("/downloads/G", [{"remote": "/downloads", "local": "/mnt/dl"}])
+    # Both the reported path and what the mapping made of it, so a mapping whose
+    # local side is wrong is distinguishable from a missing mount.
+    assert "/downloads/G" in caplog.text
+    assert str(Path("/mnt/dl/G")) in caplog.text
+
+
+def test_a_path_that_does_exist_warns_about_nothing(tmp_path, caplog):
+    real = tmp_path / "here.zip"
+    real.write_bytes(b"x")
+    with caplog.at_level(logging.WARNING):
+        assert map_remote_path(str(real), []) == real
+    assert caplog.text == ""
 
 
 # --- api key hygiene ------------------------------------------------------


### PR DESCRIPTION
The downloads volume comment in `docker-compose.yml` never said which side of the colon it meant, and its example contradicted the line beneath it:

```yaml
# If qBittorrent says /downloads/complete, mount it at /downloads/complete here.
- /path/to/downloads:/downloads
```

A reader cannot tell whether to change the right side. The library volume two lines up gets this right — *"the left side is the host; the right side must match LIBRARY_PATH"* — so the inconsistency reads as meaningful rather than accidental.

Reported by a user who had followed other apps' instructions asking for the **host** path, while another reader took it as the **container** path. Both readings are half true, which is the problem: the host side only has to be the directory holding the files, and the container side is the one that must match what the client reports.

## Docs

The comment now names the sides, works the example through with *both* sides changing, covers the client-on-the-host case where they end up identical, and says where qBittorrent and SABnzbd display the value so it can be copied rather than guessed.

## A wrong mount also failed unhelpfully

It reported `download path does not exist`, which sends people hunting for a download that is sitting in their client — the file is fine, this process just cannot see that path.

- The reason now says "in this container", names the path tried, and gives both remedies.
- `map_remote_path` warns when the path it returns is not openable. It is the only place that knows both the reported and the translated path, and the difference between them is the whole diagnosis — it distinguishes a missing mount from a mapping whose local side is wrong.

## Tests

`map_remote_path` had none. Added: prefix rewriting, longest-match-wins regardless of row order, half-filled mapping rows being ignored, Windows-style remote paths, and the warning behaviour both ways.

149 tests pass. `docker compose config` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)