### PR TITLE
Default to port 6868, because 7878 is Radarr's

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ NZBGET_PASS=
 # NZBGET_CATEGORY=romarr
 
 # ROMarr itself
-ROMARR_PORT=7878
+ROMARR_PORT=6868
 LOG_LEVEL=INFO
 
 # Nothing loads this file for you -- there is no dotenv dependency. Use it as a

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,18 +37,18 @@ RUN chmod +x /entrypoint.sh && mkdir -p /config /roms
 # setting it here would silently ignore the ROMM_LIBRARY an existing install
 # brought with it. The entrypoint defaults it only when neither name is given.
 ENV ROMARR_DATA=/config/romarr.json \
-    ROMARR_PORT=7878 \
+    ROMARR_PORT=6868 \
     PUID=1000 \
     PGID=1000 \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 VOLUME /config
-EXPOSE 7878
+EXPOSE 6868
 
 # Python is already here, so the healthcheck needs no curl. A non-200 raises.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import os,urllib.request;urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('ROMARR_PORT','7878')+'/api/health',timeout=4)"
+    CMD python -c "import os,urllib.request;urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('ROMARR_PORT','6868')+'/api/health',timeout=4)"
 
 LABEL org.opencontainers.image.title="ROMarr" \
       org.opencontainers.image.description="The *arr for games: request a ROM, ROMarr finds it via Prowlarr, grabs it, and files it into your game library" \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you run Radarr for films and Sonarr for TV, this is the missing one.
 ### Docker
 
 ```bash
-docker run -d --name romarr -p 7878:7878 \
+docker run -d --name romarr -p 6868:6868 \
   -e PUID=1000 -e PGID=1000 \
   -e PROWLARR_URL=http://prowlarr:9696 -e PROWLARR_API_KEY=... \
   -e LIBRARY_URL=http://romm:8080 -e LIBRARY_USERNAME=romarr -e LIBRARY_PASSWORD=... \
@@ -67,7 +67,17 @@ docker run -d --name romarr -p 7878:7878 \
   ghcr.io/blizzhacker/romarr:latest
 ```
 
-Open `http://localhost:7878`.
+Open `http://localhost:6868`.
+
+> **Upgrading from 0.6.x?** The default port changed from **7878 to 6868**.
+> 7878 is Radarr's port, and running both is the normal case rather than the
+> exception, so ROMarr was colliding with it on a default install. 6868 sits in
+> the gap the \*arr family left between Bazarr (6767) and Whisparr (6969).
+>
+> If you pinned the port yourself — `ROMARR_PORT`, or a `7878:7878` mapping —
+> nothing changes until you remove the pin. If you relied on the default,
+> update your port mapping to `6868:6868`, or set `ROMARR_PORT=7878` to keep
+> the old one.
 
 Images are published for `linux/amd64`, `linux/arm64` and `linux/arm/v7`.
 

--- a/docker-compose-alt.yml
+++ b/docker-compose-alt.yml
@@ -13,7 +13,7 @@ services:
     container_name: romarr
     restart: unless-stopped
     ports:
-      - "7878:7878"
+      - "6868:6868"
     environment:
       # Who owns the ROMs ROMarr writes. Use the same ids as your library app,
       # or `id -u` / `id -g` for your media user.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     container_name: romarr
     restart: unless-stopped
     ports:
-      - "7878:7878"
+      - "6868:6868"
     environment:
       # Who owns the ROMs ROMarr writes. Use the same ids as your library app,
       # or `id -u` / `id -g` for your media user.

--- a/proxmox/ct/romarr.sh
+++ b/proxmox/ct/romarr.sh
@@ -62,4 +62,4 @@ description
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:7878${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:6868${CL}"

--- a/proxmox/install/romarr-install.sh
+++ b/proxmox/install/romarr-install.sh
@@ -45,7 +45,7 @@ ROMM_PASSWORD=
 # import succeeds and the game never appears.
 ROMM_LIBRARY=/mnt/roms
 ROMARR_DATA=/opt/romarr/romarr.json
-ROMARR_PORT=7878
+ROMARR_PORT=6868
 LOG_LEVEL=INFO
 EOF
 chmod 600 /opt/romarr/.env

--- a/proxmox/json/romarr.json
+++ b/proxmox/json/romarr.json
@@ -9,7 +9,7 @@
   "updateable": true,
   "privileged": false,
   "has_arm": true,
-  "interface_port": 7878,
+  "interface_port": 6868,
   "documentation": "https://github.com/BlizzHacker/romarr#readme",
   "website": "https://github.com/BlizzHacker/romarr",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/romm.webp",

--- a/romarr/__main__.py
+++ b/romarr/__main__.py
@@ -10,7 +10,7 @@ def main() -> None:
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    serve(port=int(os.environ.get("ROMARR_PORT", "7878")))
+    serve(port=int(os.environ.get("ROMARR_PORT", "6868")))
 
 
 if __name__ == "__main__":

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -63,7 +63,7 @@ from .ui import page as ui_page
 
 log = logging.getLogger(__name__)
 
-VERSION = "0.6.1"
+VERSION = "0.7.0"
 
 # What ROMarr labels its own downloads with, so its jobs are distinguishable
 # from everything else in a shared client -- the same reason Radarr and Sonarr
@@ -1407,7 +1407,7 @@ def make_handler(service: ROMarr):
     return Handler
 
 
-def serve(port: int = 7878, env: dict[str, str] | None = None):
+def serve(port: int = 6868, env: dict[str, str] | None = None):
     service = ROMarr(env)
     httpd = ThreadingHTTPServer(("0.0.0.0", port), make_handler(service))
     log.info("ROMarr listening on :%d, library=%s", port, service.library)


### PR DESCRIPTION
ROMarr shipped on **7878 — that is Radarr's port**, and anyone running ROMarr is running Radarr; that is literally the pitch. So the default collided with the one application every target user already has.

**6868** sits in the gap the \*arr family left: Bazarr 6767, **ROMarr 6868**, Whisparr 6969. Verified unused across the Runtipi, Big Bear and Umbrel catalogues. Its only registration is `acctopus-cc`, which no self-hoster runs. 7979 was rejected for sitting next to 7878, which is where a second Radarr goes.

Verified at runtime, not just in the constant: serves 200 on `/api/health` at 6868, reports 0.7.0, and 7878 refuses. 218 tests pass.

Breaking for anyone who relied on the default rather than pinning it — README gives both ways out.