### PR TITLE
Every game, every platform: remove the disc-based exclusion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,9 @@ LOG_LEVEL=INFO
 # Nothing loads this file for you -- there is no dotenv dependency. Use it as a
 # systemd EnvironmentFile, hand it to Docker as env_file, or source it:
 #   set -a; . ./.env; set +a
+
+# Optional headless RetroArch stream server. Read-only: ROMarr asks it which
+# platforms it can play, and uses the answer to report PS2, GameCube, Wii,
+# Dreamcast and 3DS as playable rather than download-only. Everything works
+# without it, minus those routes.
+# STREAM_SERVER_URL=http://romm-stream:8090

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,13 @@ FROM python:3.13-alpine
 
 # su-exec drops privileges in the entrypoint; it takes numeric ids, so no
 # shadow package and no user has to exist in the image. tzdata makes TZ work.
-RUN apk add --no-cache su-exec tzdata
+#
+# libarchive-tools provides bsdtar, which is what reads .7z and .rar. It is
+# not optional cargo: the disc platforms this image now supports ship almost
+# entirely as .7z, so without it every PlayStation, PS2 and Wii import fails
+# on a format it cannot open. Alpine's busybox `tar` is not a substitute and
+# is deliberately not accepted -- see romarr/library.py::_bsdtar.
+RUN apk add --no-cache su-exec tzdata libarchive-tools
 
 COPY --from=builder /install /usr/local
 

--- a/README.md
+++ b/README.md
@@ -211,9 +211,13 @@ Platforms page rather than making you find out at the point of clicking play.
 
 - **Atari Jaguar CD** — no emulator plays it. `virtualjaguar` is the only
   Jaguar core in libretro and declares `j64|jag|rom|abs|cof|bin|prg`:
-  cartridges, no `cue`, no `chd`. Jaguar *cartridges* play fine.
-- **MSX, MSX2, Sharp X68000** — the cores are installed; they need system
-  firmware you supply from your own hardware. ROMarr names the exact files.
+  cartridges, no `cue`, no `chd`. MAME's own source marks its `jaguarcd`
+  driver `MACHINE_NOT_WORKING`. Jaguar *cartridges* play fine.
+- **Sharp X68000** — `px68k` is installed and needs Sharp's `iplrom.dat` and
+  `cgrom.dat`, which you supply from your own hardware. There is no free
+  equivalent the way C-BIOS exists for MSX.
+
+Everything else on the list plays.
 
 Everything else plays. Where a stream server has the core but not the
 firmware it says *that*, because a core with no BIOS does not fail loudly: it

--- a/README.md
+++ b/README.md
@@ -190,9 +190,14 @@ are four routes and the last one is not a failure:
 | Route | What it is |
 |---|---|
 | **EmulatorJS** | In the browser, from your library server. Covers nine optical systems on a stock RomM: PlayStation, PSP, Saturn, Sega CD, 3DO, CD-i, PC-FX, TurboGrafx-CD and Amiga CD32. |
-| **Stream** | A headless RetroArch server renders server-side and streams the video. This is how PS2, GameCube, Wii, Dreamcast and 3DS play. Set `STREAM_SERVER_URL`. |
+| **Stream** | A headless RetroArch server renders server-side and streams the video. This is how PS2, GameCube, Wii, Dreamcast, 3DS and Neo Geo CD play. Set `STREAM_SERVER_URL`. |
 | **Archive.org** | Their in-page emulator. Real for cartridge and home-computer systems; Archive.org does **not** emulate disc systems, so ROMarr does not claim it for them. |
 | **Download** | Always. |
+
+One platform has no player anywhere: **Atari Jaguar CD**. `virtualjaguar` is
+the only Jaguar core in libretro and declares `j64|jag|rom|abs|cof|bin|prg` —
+cartridges, no `cue` and no `chd`. ROMarr reports that rather than pretending
+otherwise. Jaguar *cartridges* play fine.
 
 Nothing is refused on these grounds — cataloguing a platform you play
 elsewhere is a legitimate thing to want. ROMarr tells you which route applies

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ application. Only `/config` is chowned.
 | `NZBGET_URL` / `NZBGET_USER` / `NZBGET_PASS` | — | Usenet client |
 | `QBITTORRENT_CATEGORY` etc. | no | Download category per client (default `romarr`) |
 | `GGREQUESTZ_URL` | no | Request front-end, shown on the status page |
+| `STREAM_SERVER_URL` | no | Headless RetroArch stream server. Read-only; it is asked which platforms it can play, so PS2, GameCube, Wii, Dreamcast and 3DS are reported as playable rather than download-only |
 | `ROMARR_DATA` | no | Path to the state file |
 | `PUID` / `PGID` / `TZ` | Docker | Process user, group, timezone |
 
@@ -166,12 +167,40 @@ LIBRARY_PATH=/mnt/roms
 
 ### Supported platforms
 
-Cartridge-era systems: NES, SNES, Game Boy / Color / Advance, N64, Genesis /
-Mega Drive, Master System, Game Gear, Atari 2600 / 7800, Lynx, TurboGrafx-16,
-WonderSwan, Neo Geo Pocket, Virtual Boy.
+**Cartridge** — NES, SNES, Game Boy / Color / Advance, N64, Genesis / Mega
+Drive, Master System, Game Gear, Atari 2600 / 7800, Lynx, TurboGrafx-16,
+WonderSwan, Neo Geo Pocket, Virtual Boy, Nintendo DS, Nintendo 3DS.
 
-Disc-based platforms are excluded — multi-gigabyte images that browser emulators
-cannot stream.
+**Disc** — PlayStation, PlayStation 2, PSP, Saturn, Sega CD / Mega-CD,
+Dreamcast, GameCube, Wii, 3DO, Philips CD-i, PC-FX, TurboGrafx-CD / PC Engine
+CD, Amiga CD32, Neo Geo CD, Atari Jaguar CD.
+
+Disc images are multi-file. A `.cue` is a few hundred bytes of text naming
+tracks, and importing it on its own gives you a library entry with a title, a
+cover and no game — so ROMarr reads the sheet, takes every track it names, and
+files the set as a directory, which is the layout RomM's scanner treats as one
+multi-part ROM. `.7z` and `.rar` are read as well as `.zip`, because that is
+what disc releases actually ship as.
+
+### How each platform plays
+
+**System → Platforms** answers this per platform for your own install. There
+are four routes and the last one is not a failure:
+
+| Route | What it is |
+|---|---|
+| **EmulatorJS** | In the browser, from your library server. Covers nine optical systems on a stock RomM: PlayStation, PSP, Saturn, Sega CD, 3DO, CD-i, PC-FX, TurboGrafx-CD and Amiga CD32. |
+| **Stream** | A headless RetroArch server renders server-side and streams the video. This is how PS2, GameCube, Wii, Dreamcast and 3DS play. Set `STREAM_SERVER_URL`. |
+| **Archive.org** | Their in-page emulator. Real for cartridge and home-computer systems; Archive.org does **not** emulate disc systems, so ROMarr does not claim it for them. |
+| **Download** | Always. |
+
+Nothing is refused on these grounds — cataloguing a platform you play
+elsewhere is a legitimate thing to want. ROMarr tells you which route applies
+before the grab instead of leaving you to find out at the point of clicking
+play, and where a platform has no player it says what would fix it. If your
+stream server has the core but not the firmware, it says *that*, because a
+core with no BIOS does not fail loudly: it draws an error screen and streams
+it at a perfectly healthy 30 fps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -167,13 +167,25 @@ LIBRARY_PATH=/mnt/roms
 
 ### Supported platforms
 
-**Cartridge** — NES, SNES, Game Boy / Color / Advance, N64, Genesis / Mega
-Drive, Master System, Game Gear, Atari 2600 / 7800, Lynx, TurboGrafx-16,
-WonderSwan, Neo Geo Pocket, Virtual Boy, Nintendo DS, Nintendo 3DS.
+58 platforms. The bar for inclusion is a real play route — a core in RomM's
+base EmulatorJS map, or one installed on a stream server.
+
+**Cartridge** — NES, Famicom, Famicom Disk System, SNES, Super Famicom, Game
+Boy / Color / Advance, N64, Genesis / Mega Drive, Sega 32X, Master System,
+Game Gear, Atari 2600 / 5200 / 7800, Lynx, Jaguar, TurboGrafx-16, SuperGrafx,
+ColecoVision, Intellivision, Vectrex, WonderSwan / Color, Neo Geo Pocket /
+Color, Neo Geo AES / MVS, Arcade, Virtual Boy, Nintendo DS, Nintendo 3DS.
 
 **Disc** — PlayStation, PlayStation 2, PSP, Saturn, Sega CD / Mega-CD,
 Dreamcast, GameCube, Wii, 3DO, Philips CD-i, PC-FX, TurboGrafx-CD / PC Engine
 CD, Amiga CD32, Neo Geo CD, Atari Jaguar CD.
+
+**Home computer** — Commodore 64 / 128 / VIC-20, Amiga, Amstrad CPC, ZX
+Spectrum, MSX / MSX2, Sharp X68000, MS-DOS.
+
+For Arcade, Neo Geo and DOS the archive **is** the ROM — MAME, FBNeo and
+dosbox_pure open the `.zip` themselves and expect its internal layout, so
+ROMarr imports it whole instead of unpacking a romset into loose chip dumps.
 
 Disc images are multi-file. A `.cue` is a few hundred bytes of text naming
 tracks, and importing it on its own gives you a library entry with a title, a
@@ -194,10 +206,18 @@ are four routes and the last one is not a failure:
 | **Archive.org** | Their in-page emulator. Real for cartridge and home-computer systems; Archive.org does **not** emulate disc systems, so ROMarr does not claim it for them. |
 | **Download** | Always. |
 
-One platform has no player anywhere: **Atari Jaguar CD**. `virtualjaguar` is
-the only Jaguar core in libretro and declares `j64|jag|rom|abs|cof|bin|prg` —
-cartridges, no `cue` and no `chd`. ROMarr reports that rather than pretending
-otherwise. Jaguar *cartridges* play fine.
+**What still cannot play, and why.** ROMarr says this per platform on the
+Platforms page rather than making you find out at the point of clicking play.
+
+- **Atari Jaguar CD** — no emulator plays it. `virtualjaguar` is the only
+  Jaguar core in libretro and declares `j64|jag|rom|abs|cof|bin|prg`:
+  cartridges, no `cue`, no `chd`. Jaguar *cartridges* play fine.
+- **MSX, MSX2, Sharp X68000** — the cores are installed; they need system
+  firmware you supply from your own hardware. ROMarr names the exact files.
+
+Everything else plays. Where a stream server has the core but not the
+firmware it says *that*, because a core with no BIOS does not fail loudly: it
+draws an error screen and streams it at a perfectly healthy 30 fps.
 
 Nothing is refused on these grounds — cataloguing a platform you play
 elsewhere is a legitimate thing to want. ROMarr tells you which route applies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,12 @@ services:
       # Optional request front-end, shown on the System page.
       # GGREQUESTZ_URL: http://ggrequestz:3000
 
+      # Optional headless RetroArch stream server. ROMarr only ever reads from
+      # it -- one GET asking which platforms it can play -- and uses the answer
+      # to report PS2, GameCube, Wii, Dreamcast and 3DS as playable instead of
+      # download-only. Everything works without it, minus those routes.
+      # STREAM_SERVER_URL: http://romm-stream:8090
+
       LOG_LEVEL: INFO
 
     volumes:

--- a/docs/superpowers/specs/2026-08-02-disc-platforms-design.md
+++ b/docs/superpowers/specs/2026-08-02-disc-platforms-design.md
@@ -17,8 +17,8 @@ vendored verbatim in `rom-hub/src/rom_hub/playability.py`, gives EmulatorJS
 cores for `psx` (`pcsx_rearmed`, `mednafen_psx_hw`), `psp` (`ppsspp`),
 `saturn` (`yabause`), `segacd` (`genesis_plus_gx`, `picodrive`), `3do`
 (`opera`), `philips-cd-i` (`same_cdi`), `pc-fx` (`mednafen_pcfx`),
-`turbografx-cd` (`mednafen_pce`), `amiga-cd32` (`puae`) and `dos`
-(`dosbox_pure`). Ten optical systems, in the base map, on any stock RomM.
+`turbografx-cd` (`mednafen_pce`) and `amiga-cd32` (`puae`). Nine optical
+systems, in the base map, on any stock RomM, with no configuration.
 
 **What EmulatorJS cannot run, the stream server already does.**
 `RommStreamServer/tiers.py` routes `ps2` → `pcsx2`, `ngc`/`wii` → `dolphin`,
@@ -117,7 +117,13 @@ this play?** Four answers, in preference order:
 - `stream` — the headless RetroArch stream server, when one is configured and
   says it can.
 - `archive` — an Archive.org `/details/` page, which runs Emularity in the
-  page; the Hub's existing `browser` handover.
+  page; the Hub's existing `browser` handover. **Measured, not assumed:**
+  Archive.org records the emulator for an item in its `emulator` metadata
+  field, which 272,424 items carry. The disc drivers return nothing —
+  `psj`/`psu`/`pse` 0 items, `saturn` 0, `3do` 0, `dc` 2, `segacd` 1, against
+  `genesis` 12,877 and `a2600` 3,123. Archive.org is a *source* for disc
+  images and not a player of them, so this route is offered only where it is
+  real.
 - `download` — always true. A ROM in the library is a ROM you can download,
   and that is a legitimate answer rather than a failure.
 
@@ -138,11 +144,24 @@ to `local`/`archive`/`download` — never to an error.
   removal already exempts the requested platform's own aliases, and each new
   platform declares aliases covering the markers that name it (`psx` declares
   `ps1`, `psx`, `playstation`).
-- `COMPILATION_MARKERS` is unchanged and still correct: a multi-game disc
-  collection is no more importable for a single-game request than a romset.
+- **`COMPILATION_MARKERS` needed one change, found during implementation.**
+  This section originally said it was "unchanged and still correct". It was
+  not: `redump` is in that list, and Redump is the disc-preservation project —
+  what No-Intro is for cartridges. Rejecting on it would have thrown out every
+  correctly-labelled disc dump and left the unlabelled ones standing, so the
+  scorer would have systematically preferred worse dumps while reporting "a
+  compilation, not a single cartridge". It is a +40 signal on disc platforms
+  and unchanged elsewhere; `Redump - … Collection` is still rejected on the
+  word that actually makes it a set.
 - **Multi-disc releases are not compilations.** `(Disc 1)` / `(Disc 2)` must
   survive scoring, because that is how the live library stores them. A new
   test pins this.
+- **`best_release`'s size tie-break inverts for discs.** Preferring the
+  smaller file is right for a cartridge, where a bigger file at the same score
+  is a romset. Two rips of one disc differ by how much of the disc was kept,
+  so the smaller is the one missing audio or video.
+- **The size floor is per medium too.** 4KB is a real floor for an Atari
+  cartridge and no floor at all for a disc.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-02-disc-platforms-design.md
+++ b/docs/superpowers/specs/2026-08-02-disc-platforms-design.md
@@ -1,0 +1,165 @@
+# Every game, every platform: removing the disc-based exclusion
+
+**Status:** approved for implementation
+**Date:** 2026-08-02
+
+## The claim being removed
+
+`README.md` says:
+
+> Disc-based platforms are excluded — multi-gigabyte images that browser
+> emulators cannot stream.
+
+Both halves are false, and the evidence is in this ecosystem's own code.
+
+**Browser emulators do run disc systems.** RomM 4.9.2's `_EJS_CORES_MAP`,
+vendored verbatim in `rom-hub/src/rom_hub/playability.py`, gives EmulatorJS
+cores for `psx` (`pcsx_rearmed`, `mednafen_psx_hw`), `psp` (`ppsspp`),
+`saturn` (`yabause`), `segacd` (`genesis_plus_gx`, `picodrive`), `3do`
+(`opera`), `philips-cd-i` (`same_cdi`), `pc-fx` (`mednafen_pcfx`),
+`turbografx-cd` (`mednafen_pce`), `amiga-cd32` (`puae`) and `dos`
+(`dosbox_pure`). Ten optical systems, in the base map, on any stock RomM.
+
+**What EmulatorJS cannot run, the stream server already does.**
+`RommStreamServer/tiers.py` routes `ps2` → `pcsx2`, `ngc`/`wii` → `dolphin`,
+`dc`/`naomi`/`atomiswave` → `flycast`, `3ds` → `citra`, `saturn` →
+`mednafen_saturn`, `n64` → `mupen64plus_next`, all server-side under headless
+RetroArch, captured and delivered over WebRTC or HLS. The client never sees
+the multi-gigabyte image.
+
+**And the library already holds them.** The production RomM at
+`/mnt/usb1/roms` carries 2,621 psx, 2,409 ps2, 1,470 wii, 1,182 psp, 992 dc,
+718 saturn, 626 ngc, 189 segacd and 167 3do entries — sitting there, playable,
+acquired by hand because ROMarr refuses to acquire them.
+
+So the exclusion never described a limitation. It described ROMarr's importer.
+
+## What actually blocks disc platforms
+
+Five places, all in ROMarr:
+
+1. **`platforms.py`** — sixteen cartridge platforms and nothing else. A disc
+   platform cannot be requested because it cannot be named.
+2. **`selection.py::judge`** — the size ceiling rejects anything over the
+   platform's `max_size`, wording the rejection "too big for a … cartridge".
+3. **`selection.py::pick_rom_file`** — returns **one** filename. A `.cue`
+   without its `.bin`, or a `.gdi` without its tracks, is a dead file. This is
+   the single most damaging assumption: it does not fail, it imports something
+   broken.
+4. **`library.py`** — copies one file, and `ARCHIVE_SUFFIXES = (".zip",)`.
+   The live disc library is overwhelmingly `.7z`.
+5. **Nothing tells the operator how a platform will play.** Three real play
+   routes exist and ROMarr surfaces none of them.
+
+## Design
+
+### 1. Platforms gain a medium
+
+`Platform` gains `media: "cartridge" | "disc" | "computer"`. It changes three
+behaviours — the size ceiling's magnitude, the wording when a release is
+rejected for size, and whether a multi-file set is expected — and it makes the
+platform table self-describing rather than encoding "disc" implicitly in a
+number.
+
+Every slug added is a RomM `fs_slug` verified against **both** the live
+library's 394 platform folders and RomM 4.9.2's own core map. No slug is
+invented.
+
+Disc ceilings are per medium, not per title: CD-based systems (psx, saturn,
+segacd, 3do, dc, pc-fx, philips-cd-i, turbografx-cd, amiga-cd32, neo-geo-cd)
+get headroom for one disc plus packaging; DVD-based (ps2, ngc, wii, psp,
+xbox) get headroom for a dual-layer image. The ceiling still does real work —
+it is what keeps a 60 GB PC repack out of a PS2 request.
+
+### 2. A ROM set, not a ROM file
+
+`pick_rom_file` is kept and reimplemented on top of a new `pick_rom_set`,
+which returns a `RomSet(primary, members)`:
+
+- **Cartridge platforms** — one member, unchanged behaviour.
+- **Disc platforms** — the preferred image by extension order, plus every
+  sidecar it references. `.cue` pulls its `.bin`/`.img` tracks; `.gdi` pulls
+  `.bin`/`.raw`. Preference order and sidecar rules are taken from
+  `RommStreamServer/archives.py`, which is the same knowledge already proven
+  against this library rather than a fresh guess.
+- A single-file image (`.chd`, `.rvz`, `.iso`, `.cso`, `.pbp`) is a set of
+  one, and is preferred over a cue/bin pair when both are present, because it
+  is one file that cannot be separated from its tracks.
+
+**Sidecars are resolved by parsing the sheet, not by pattern.** A `.cue` names
+its tracks in `FILE "…" BINARY` lines; a `.gdi` lists them positionally. A
+glob of "every `.bin` next to it" is wrong for a directory holding two discs.
+When the sheet cannot be read, every same-stem companion is taken — over-
+inclusive, which costs disk, rather than under-inclusive, which costs a
+playable game.
+
+### 3. Importing a set
+
+`import_rom` keeps its signature and return type. When the chosen set has one
+member the destination is unchanged: `<library>/<slug>/<file>`. When it has
+several, the destination is a directory — `<library>/<slug>/<stem>/` holding
+every member — which is the layout the live library already uses (`dc/102
+Dalmatians …/` holds a `.gdi` and five tracks).
+
+`ARCHIVE_SUFFIXES` grows to `.zip`, `.7z`, `.rar`. Zip stays on stdlib
+`zipfile`; 7z and rar go through `bsdtar`, which is what the stream server
+uses and reads all three uniformly. Zip-slip checking is applied to every
+format, not just zip — the check moves to a shared `safe_names` helper so one
+format cannot be protected and another not. Where `bsdtar` is absent the
+import fails with a message naming the missing tool, never silently.
+
+### 4. Playability, stated up front
+
+A new `romarr/playability.py` answers one question per platform: **how will
+this play?** Four answers, in preference order:
+
+- `local` — EmulatorJS in the browser (RomM's base core map).
+- `stream` — the headless RetroArch stream server, when one is configured and
+  says it can.
+- `archive` — an Archive.org `/details/` page, which runs Emularity in the
+  page; the Hub's existing `browser` handover.
+- `download` — always true. A ROM in the library is a ROM you can download,
+  and that is a legitimate answer rather than a failure.
+
+Nothing here refuses an import — that is `rom-hub/playability.py`'s rule and
+it is the right one. The answer is displayed beside the platform in the UI and
+returned on `/api/v1/system/status`, so the operator knows before the grab
+rather than at the point of clicking play.
+
+The stream-server tier is asked at runtime over the two read-only GETs
+`StreamServerClient` already uses, and its answer is cached per platform for
+the process lifetime. When no stream server is configured the answer degrades
+to `local`/`archive`/`download` — never to an error.
+
+### 5. Scoring changes
+
+- The size-ceiling message says "disc image" for disc platforms.
+- `FOREIGN_PLATFORM_MARKERS` keeps every marker; the existing `own`-set
+  removal already exempts the requested platform's own aliases, and each new
+  platform declares aliases covering the markers that name it (`psx` declares
+  `ps1`, `psx`, `playstation`).
+- `COMPILATION_MARKERS` is unchanged and still correct: a multi-game disc
+  collection is no more importable for a single-game request than a romset.
+- **Multi-disc releases are not compilations.** `(Disc 1)` / `(Disc 2)` must
+  survive scoring, because that is how the live library stores them. A new
+  test pins this.
+
+## Testing
+
+- `pick_rom_set` against real filename layouts: cue+bin, gdi+tracks, a
+  directory holding two discs, a bare `.chd`, a `.7z` of any of them.
+- `import_rom` proving a multi-member set lands as a directory with every
+  member present, and that a `.cue` never arrives without its `.bin`.
+- Zip-slip refused identically across zip, 7z and rar.
+- Scoring: a 4 GB PS2 image accepted, a 60 GB repack rejected, a 2.3 MB
+  Genesis dump still preferred over a compilation, `(Disc 1)` not rejected.
+- Playability: every platform in the table resolves to at least one route, and
+  the route for each disc platform is asserted against RomM's vendored core
+  map rather than restated.
+
+## Proof before the README changes
+
+The README is rewritten **last**, and only against a real run: a disc-platform
+request searched, scored, grabbed, picked as a set, imported to a disposable
+backend (`demoromm` on CT 104 — never production `romm`), and the resulting
+entry shown to route to a real play tier.

--- a/docs/superpowers/specs/2026-08-02-disc-proof.py
+++ b/docs/superpowers/specs/2026-08-02-disc-proof.py
@@ -4,6 +4,7 @@ Nothing here is a fixture: the .7z is a real PlayStation release copied out of
 /mnt/usb1/roms/psx, and the .gdi is the real sheet from the live Dreamcast
 entry `dc/Pop'n Music (JP, Rev 1.2)/`.
 """
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -97,13 +98,42 @@ for title, size, want, platform, expected in cases:
 
 print()
 print("=" * 74)
-print("4. Play routes, against the REAL stream server on 192.168.0.94:8090")
+print("4. Every platform has a route -- against the REAL stream server")
 print("=" * 74)
-stream = StreamServer("http://192.168.0.94:8090")
-for slug in ("psx", "psp", "saturn", "segacd", "3do", "ps2", "ngc", "wii", "dc"):
-    got = routes_for(by_slug(slug), stream=stream)
-    print(f"  {slug:10} {','.join(got.kinds)}")
-    check(f"{slug} has a route", bool(got.kinds))
+from romarr.platforms import PLATFORMS
+
+stream = StreamServer(os.environ.get("STREAM_SERVER_URL",
+                                    "http://192.168.0.94:8090"))
+by_kind: dict[str, int] = {}
+no_player = []
+for platform in PLATFORMS:
+    got = routes_for(platform, stream=stream)
+    check(f"{platform.slug} has a route", bool(got.kinds))
+    for kind in got.kinds:
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+    if not got.plays_without_downloading:
+        no_player.append(got.summary())
+
+print()
+print(f"  {len(PLATFORMS)} platforms: " +
+      ", ".join(f"{k} {v}" for k, v in sorted(by_kind.items())))
+print()
+print("  No player (each must state a specific reason, not a generic one):")
+for line in no_player:
+    print("   -", line)
+    check("the reason is specific",
+          "no browser core for this platform" not in line)
+
+# The exclusion this whole change exists to remove: every disc platform must
+# be requestable, and all but Jaguar CD must be playable somewhere.
+disc = [p for p in PLATFORMS if p.is_disc]
+playable_disc = [p for p in disc
+                 if routes_for(p, stream=stream).plays_without_downloading]
+print()
+check(f"disc platforms present ({len(disc)})", len(disc) >= 15)
+check(f"disc platforms playable ({len(playable_disc)}/{len(disc)})",
+      len(playable_disc) >= len(disc) - 1,
+      "only Atari Jaguar CD may lack a player -- no emulator exists for it")
 
 print()
 print("=" * 74)

--- a/docs/superpowers/specs/2026-08-02-disc-proof.py
+++ b/docs/superpowers/specs/2026-08-02-disc-proof.py
@@ -1,0 +1,112 @@
+"""End-to-end proof against real files from the live library.
+
+Nothing here is a fixture: the .7z is a real PlayStation release copied out of
+/mnt/usb1/roms/psx, and the .gdi is the real sheet from the live Dreamcast
+entry `dc/Pop'n Music (JP, Rev 1.2)/`.
+"""
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, r"C:\MoveWeight\romarr-wt-disc")
+
+from romarr.library import import_rom, list_candidates
+from romarr.platforms import by_slug
+from romarr.playability import routes_for, StreamServer
+from romarr.selection import Release, best_release, judge, pick_rom_set
+
+HERE = Path(__file__).parent
+LIB = HERE / "library"
+if LIB.exists():
+    shutil.rmtree(LIB)
+
+ok = True
+
+
+def check(label, condition, detail=""):
+    global ok
+    ok = ok and bool(condition)
+    print(f"  [{'PASS' if condition else 'FAIL'}] {label}" + (f" -- {detail}" if detail else ""))
+
+
+print("=" * 74)
+print("1. A REAL PlayStation .7z from the live library")
+print("=" * 74)
+seven = HERE / "RoboCop (Prototype 1997-08-07).7z"
+psx = by_slug("psx")
+names = list_candidates(seven)
+print(f"  archive holds: {names}")
+chosen = pick_rom_set(names, psx, read=None)
+print(f"  primary: {chosen.primary}")
+print(f"  members: {chosen.members}")
+check("the .7z can be opened at all", len(names) == 2)
+check("the .cue is the primary", chosen.primary.endswith(".cue"))
+check("the .bin travels with it", any(m.endswith(".bin") for m in chosen.members))
+
+result = import_rom(seven, psx, LIB)
+print(f"  import: ok={result.ok} destination={result.destination}")
+landed = sorted(p.name for p in result.destination.iterdir()) if result.ok else []
+print(f"  landed: {landed}")
+check("import succeeded", result.ok, result.reason)
+check("both files are in the library", len(landed) == 2)
+check("filed under psx", result.destination.parent.name == "psx")
+
+print()
+print("=" * 74)
+print("2. The REAL Dreamcast multi-track layout (sheet copied verbatim)")
+print("=" * 74)
+dc_src = HERE / "dc-download"
+dc_src.mkdir(exist_ok=True)
+gdi = "Pop'n Music v1.200 (1998)(Konami)(NTSC)(JP)(en)[!].gdi"
+(dc_src / gdi).write_text(
+    "3\n1 0 4 2352 track01.bin 0\n2 935 0 2352 track02.raw 0\n"
+    "3 45000 4 2352 track03.bin 0\n")
+for track in ("track01.bin", "track02.raw", "track03.bin"):
+    (dc_src / track).write_bytes(b"\0" * 4096)
+(dc_src / "readme.nfo").write_text("scene notes")
+
+dc = by_slug("dc")
+result = import_rom(dc_src, dc, LIB)
+landed = sorted(p.name for p in result.destination.iterdir()) if result.ok else []
+print(f"  import: ok={result.ok}")
+print(f"  destination: {result.destination}")
+print(f"  landed: {landed}")
+check("import succeeded", result.ok, result.reason)
+check("landed as a directory", result.ok and result.destination.is_dir())
+check("the sheet and all three tracks landed", len(landed) == 4)
+check("the .nfo did not", "readme.nfo" not in landed)
+check("track01.bin is present", "track01.bin" in landed)
+
+print()
+print("=" * 74)
+print("3. Scoring real-shaped disc releases")
+print("=" * 74)
+cases = [
+    ("Final Fantasy VII (USA) (Disc 1)", 600 * 1024**2, "final fantasy vii", psx, True),
+    ("Silent Hill (USA) [Redump]", 500 * 1024**2, "silent hill", psx, True),
+    ("Shadow of the Colossus (USA)", 4 * 1024**3, "shadow of the colossus", by_slug("ps2"), True),
+    ("Shadow of the Colossus REPACK", 60 * 1024**3, "shadow of the colossus", by_slug("ps2"), False),
+    ("Redump - Sony PlayStation USA Collection", 400 * 1024**3, "silent hill", psx, False),
+    ("Silent Hill (USA) PS2", 500 * 1024**2, "silent hill", psx, False),
+]
+for title, size, want, platform, expected in cases:
+    verdict = judge(Release(title, size, 25, (1000,), "magnet:?x", "torrent"), want, platform)
+    check(f"{title[:46]:46} -> {'accept' if expected else 'reject'}",
+          verdict.accepted == expected,
+          "" if verdict.accepted == expected else verdict.why()[0])
+
+print()
+print("=" * 74)
+print("4. Play routes, against the REAL stream server on 192.168.0.94:8090")
+print("=" * 74)
+stream = StreamServer("http://192.168.0.94:8090")
+for slug in ("psx", "psp", "saturn", "segacd", "3do", "ps2", "ngc", "wii", "dc"):
+    got = routes_for(by_slug(slug), stream=stream)
+    print(f"  {slug:10} {','.join(got.kinds)}")
+    check(f"{slug} has a route", bool(got.kinds))
+
+print()
+print("=" * 74)
+print("RESULT:", "ALL PROOFS PASSED" if ok else "SOMETHING FAILED")
+print("=" * 74)
+sys.exit(0 if ok else 1)

--- a/proxmox/install/romarr-install.sh
+++ b/proxmox/install/romarr-install.sh
@@ -14,7 +14,10 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y python3-venv
+# libarchive-tools provides bsdtar, which reads the .7z and .rar archives the
+# disc platforms ship as. Without it every PlayStation, PS2 and Wii import
+# fails on a format it cannot open. Debian's GNU tar is not a substitute.
+$STD apt-get install -y python3-venv libarchive-tools
 msg_ok "Installed Dependencies"
 
 fetch_and_deploy_gh_release "romarr" "BlizzHacker/romarr" "tarball" "latest" "/opt/romarr"

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -57,6 +57,7 @@ from .indexers import INDEXER_TYPES, build_indexer, redact_indexer
 from .indexers import Prowlarr, ProwlarrConfig
 from .library import import_rom, map_remote_path
 from .platforms import PLATFORMS, resolve
+from .playability import DOWNLOAD, StreamServer, routes_for
 from .selection import best_release, judge, score
 from .store import Event, Store
 from .ui import page as ui_page
@@ -198,6 +199,17 @@ class ROMarr:
         self.store.settings["_prowlarr_url"] = e.get("PROWLARR_URL", "")
         self.store.settings["_qbit_url"] = e.get("QBITTORRENT_URL", "")
         self.store.settings["_romm_url"] = e.get("ROMM_URL", "")
+
+        # The headless RetroArch stream server, if the operator runs one. It is
+        # what plays the machines EmulatorJS has no core for -- PS2, GameCube,
+        # Wii, Dreamcast, 3DS -- so whether one is configured changes the
+        # honest answer to "will this play", and nothing else here.
+        #
+        # Optional by design: ROMarr must work identically without it, minus
+        # the routes only it can offer.
+        stream_url = e.get("STREAM_SERVER_URL", "")
+        self.store.settings["_stream_url"] = stream_url
+        self.stream = StreamServer(stream_url) if stream_url else None
 
         self._seed_from_env(e)
         self.reload_clients()
@@ -1044,9 +1056,49 @@ class ROMarr:
             "library_path_hint": self.path_hint(self.library),
             "libraries": self.libraries_status(),
             "platforms": len(PLATFORMS),
+            "play_routes": self.play_route_counts(),
+            "stream_url": self.store.settings.get("_stream_url", ""),
             "events": len(self.store.events),
             "uptime": f"{up // 3600}h {(up % 3600) // 60}m",
         }
+
+    def play_route_counts(self) -> dict:
+        """How many supported platforms are playable, and by which route.
+
+        On the status page because the answer changes with the operator's own
+        setup -- configuring a stream server moves five platforms out of
+        `download_only` -- and because an install where that number is
+        surprising is one where something is misconfigured.
+        """
+        counts: dict[str, int] = {}
+        download_only = 0
+        for platform in PLATFORMS:
+            routes = routes_for(platform, stream=self.stream)
+            if not routes.plays_without_downloading:
+                download_only += 1
+            for kind in routes.kinds:
+                if kind != DOWNLOAD:
+                    counts[kind] = counts.get(kind, 0) + 1
+        counts["download_only"] = download_only
+        counts["total"] = len(PLATFORMS)
+        return counts
+
+    def platform_directory(self) -> list[dict]:
+        """Every platform with how it plays, for the API and the UI."""
+        out = []
+        for platform in PLATFORMS:
+            routes = routes_for(platform, stream=self.stream)
+            out.append({
+                "slug": platform.slug,
+                "name": platform.name,
+                "media": platform.media,
+                "extensions": list(platform.extensions),
+                "max_size_mb": platform.max_size // (1024 * 1024),
+                "play_routes": list(routes.kinds),
+                "plays": routes.plays_without_downloading,
+                "how": routes.summary(),
+            })
+        return out
 
     # How often the count and library are refreshed in the background.
     COUNT_TTL = 300
@@ -1273,7 +1325,7 @@ def make_handler(service: ROMarr):
             if route.path == "/api/health":
                 return self._json(200, service.health())
             if route.path == "/api/platforms":
-                return self._json(200, [{"slug": p.slug, "name": p.name} for p in PLATFORMS])
+                return self._json(200, service.platform_directory())
             if route.path == "/api/queue":
                 return self._json(200, [asdict(i) for i in service.queue])
             if route.path == "/api/v1/release":

--- a/romarr/library.py
+++ b/romarr/library.py
@@ -14,17 +14,75 @@ details it does handle are the ones that silently corrupt a library:
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import subprocess
 import zipfile
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 from .platforms import Platform
-from .selection import pick_rom_file
+from .selection import pick_rom_set
 
 log = logging.getLogger(__name__)
 
-ARCHIVE_SUFFIXES = (".zip",)
+#: Formats a finished download arrives in.
+#:
+#: `.zip` was the whole list, which was survivable while only cartridges were
+#: supported. It is not survivable now: the live library's disc platforms are
+#: overwhelmingly `.7z` -- 2,621 PlayStation entries, 2,409 PS2, 1,470 Wii --
+#: and an importer that cannot open the format the content ships in supports
+#: the platform on paper only.
+ARCHIVE_SUFFIXES = (".zip", ".7z", ".rar")
+
+#: Handled by the standard library, with no tool to install.
+_STDLIB_ARCHIVES = (".zip",)
+
+
+def _bsdtar() -> str | None:
+    """A libarchive `bsdtar`, which reads 7z, rar and zip uniformly.
+
+    `RommStreamServer` already reaches for exactly this and for the same
+    reason, so this is a second user of a proven choice rather than a new
+    dependency. Windows ships it as `tar.exe`; Alpine needs
+    `libarchive-tools`, which the Dockerfile installs.
+
+    GNU tar is explicitly rejected. It answers to the same name on most Linux
+    systems and cannot read a 7z, so accepting it on name alone would turn a
+    missing dependency into a corrupt-archive error pointing at the download.
+
+    Every `PATH` entry is searched rather than the first hit per name, because
+    a machine with both is the normal case, not a corner: Windows ships
+    libarchive as `System32\\tar.exe` while Git for Windows puts GNU tar
+    earlier on the same `PATH`, and a Linux box with `libarchive-tools`
+    installed alongside GNU tar looks identical. Stopping at the first binary
+    called `tar` finds the one that cannot do the job and concludes the job
+    cannot be done.
+    """
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        for name in ("bsdtar", "tar"):
+            path = shutil.which(name, path=directory)
+            if path and _is_libarchive(path):
+                return path
+    return None
+
+
+def _is_libarchive(path: str) -> bool:
+    try:
+        out = subprocess.run([path, "--version"], capture_output=True,
+                             text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "libarchive" in (out.stdout + out.stderr).lower()
+
+
+@lru_cache(maxsize=1)
+def bsdtar_path() -> str | None:
+    """`_bsdtar()`, resolved once. `None` when no usable tool is installed."""
+    return _bsdtar()
 
 
 @dataclass(frozen=True)
@@ -34,40 +92,165 @@ class ImportResult:
     reason: str = ""
 
 
+def is_safe_name(name: str, root: Path) -> bool:
+    """Whether extracting `name` under `root` stays under `root`.
+
+    Applied to every format, not only zip. The check used to live inside the
+    zip reader, so adding 7z and rar would have added two formats with no
+    zip-slip protection at all -- and the format an attacker chooses is the one
+    with the gap.
+    """
+    if not name or name.endswith(("/", "\\")):
+        return False
+    root_resolved = root.resolve()
+    return (root_resolved / name).resolve().is_relative_to(root_resolved)
+
+
 def safe_members(archive: zipfile.ZipFile, root: Path) -> list[str]:
     """Archive entries that stay inside `root` when extracted.
 
     A zip may contain absolute paths or `../` traversal. Extracting those writes
-    outside the library — the classic zip-slip. Anything that does not resolve
+    outside the library -- the classic zip-slip. Anything that does not resolve
     inside root is dropped rather than sanitised, because a release that needs
     sanitising is not one to trust.
     """
-    keep: list[str] = []
-    root_resolved = root.resolve()
+    keep = []
     for name in archive.namelist():
         if name.endswith("/"):
             continue
-        target = (root_resolved / name).resolve()
-        if target.is_relative_to(root_resolved):
+        if is_safe_name(name, root):
             keep.append(name)
         else:
             log.warning("refusing archive entry outside root: %r", name)
     return keep
 
 
+class _Source:
+    """Where the files of a finished download are, and how to get at them.
+
+    Three shapes exist -- a zip, an archive only `bsdtar` can read, and a plain
+    file or directory the client already unpacked -- and each answers the same
+    three questions. `pick_rom_set` needs `read` to parse a `.cue`, and only
+    something that knows the shape can provide it.
+    """
+
+    def names(self) -> list[str]:
+        raise NotImplementedError
+
+    def read(self, name: str) -> bytes | None:
+        raise NotImplementedError
+
+    def copy(self, name: str, destination: Path) -> None:
+        raise NotImplementedError
+
+
+class _ZipSource(_Source):
+    def __init__(self, path: Path):
+        self.path = path
+
+    def names(self):
+        with zipfile.ZipFile(self.path) as archive:
+            return safe_members(archive, self.path.parent)
+
+    def read(self, name):
+        with zipfile.ZipFile(self.path) as archive:
+            return archive.read(name)
+
+    def copy(self, name, destination):
+        with zipfile.ZipFile(self.path) as archive, \
+                archive.open(name) as src, open(destination, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+
+class _BsdtarSource(_Source):
+    """7z and rar, via libarchive.
+
+    Every member is read by re-invoking `bsdtar` rather than unpacking the
+    archive once. A disc release is a handful of files and the sheet is a few
+    hundred bytes, so the cost is small -- and unpacking the whole thing means
+    materialising up to twelve gigabytes to keep four of them.
+    """
+
+    def __init__(self, path: Path, tool: str):
+        self.path = path
+        self.tool = tool
+
+    def _run(self, args: list[str], **kw):
+        return subprocess.run([self.tool, *args], capture_output=True,
+                              check=True, timeout=600, **kw)
+
+    def names(self):
+        out = self._run(["-tf", str(self.path)], text=True)
+        return [n for n in (line.strip() for line in out.stdout.splitlines())
+                if n and not n.endswith("/") and is_safe_name(n, self.path.parent)]
+
+    def read(self, name):
+        return self._run(["-xOf", str(self.path), name]).stdout
+
+    def copy(self, name, destination):
+        with open(destination, "wb") as dst:
+            subprocess.run([self.tool, "-xOf", str(self.path), name],
+                           stdout=dst, check=True, timeout=600)
+
+
+class _PathSource(_Source):
+    """A bare ROM file, or a directory the download client already unpacked."""
+
+    def __init__(self, path: Path):
+        self.path = path
+
+    def names(self):
+        if self.path.is_file():
+            return [self.path.name]
+        return [str(p.relative_to(self.path)).replace("\\", "/")
+                for p in self.path.rglob("*") if p.is_file()]
+
+    def read(self, name):
+        target = self.path if self.path.is_file() else self.path / name
+        try:
+            return target.read_bytes()
+        except OSError:
+            return None
+
+    def copy(self, name, destination):
+        source = self.path if self.path.is_file() else self.path / name
+        shutil.copy2(source, destination)
+
+
+class MissingArchiveTool(Exception):
+    """The download is in a format no installed tool can open."""
+
+
+def _source_for(download: Path) -> _Source:
+    suffix = download.suffix.lower()
+    if download.is_file() and suffix in _STDLIB_ARCHIVES:
+        return _ZipSource(download)
+    if download.is_file() and suffix in ARCHIVE_SUFFIXES:
+        tool = bsdtar_path()
+        if tool is None:
+            raise MissingArchiveTool(
+                f"{download.name} is a {suffix} archive and bsdtar is not "
+                "installed, so its contents cannot be read. Install "
+                "libarchive-tools (Debian/Alpine) or use the official ROMarr "
+                "image, which ships it.")
+        return _BsdtarSource(download, tool)
+    return _PathSource(download)
+
+
 def list_candidates(download: Path) -> list[str]:
-    """Every file a completed download offers, looking inside a zip if needed."""
-    if download.is_file() and download.suffix.lower() in ARCHIVE_SUFFIXES:
-        with zipfile.ZipFile(download) as archive:
-            return safe_members(archive, download.parent)
-    if download.is_file():
-        return [download.name]
-    return [str(p.relative_to(download)) for p in download.rglob("*") if p.is_file()]
+    """Every file a completed download offers, looking inside an archive if needed."""
+    return _source_for(download).names()
 
 
 def import_rom(download: Path, platform: Platform, library_root: Path, *,
                overwrite: bool = False) -> ImportResult:
-    """Place the ROM from a finished download into RomM's library."""
+    """Place the ROM from a finished download into RomM's library.
+
+    A cartridge lands as one file, exactly as before. A disc lands as a
+    directory holding every file of the set, which is the layout the live
+    library already uses for multi-track rips -- so a disc ROMarr imported is
+    indistinguishable from one filed by hand.
+    """
     if not download.exists():
         # Almost always a mount problem rather than a missing download: the
         # client has the file and reported where IT sees it, and this process
@@ -81,8 +264,13 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
             "path, or add a remote path mapping under Settings -> Media "
             "Management.")
 
-    candidates = list_candidates(download)
-    chosen = pick_rom_file(candidates, platform)
+    try:
+        source = _source_for(download)
+        candidates = source.names()
+    except MissingArchiveTool as exc:
+        return ImportResult(False, None, str(exc))
+
+    chosen = pick_rom_set(candidates, platform, read=source.read)
     if chosen is None:
         return ImportResult(
             False, None,
@@ -90,23 +278,55 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
         )
 
     target_dir = library_root / platform.slug
-    target_dir.mkdir(parents=True, exist_ok=True)
-    destination = target_dir / Path(chosen).name
 
-    if destination.exists() and not overwrite:
+    # A set of one keeps the layout it has always had. Wrapping every
+    # cartridge in a directory would rewrite the shape of an existing library
+    # for no gain.
+    if not chosen.is_multi_file:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        destination = target_dir / Path(chosen.primary).name
+        if destination.exists() and not overwrite:
+            return ImportResult(False, destination, "already in the library")
+        source.copy(chosen.primary, destination)
+        log.info("imported %s -> %s", chosen.primary, destination)
+        return ImportResult(True, destination)
+
+    destination = target_dir / _set_name(chosen.primary)
+    if destination.exists() and any(destination.iterdir()) and not overwrite:
         return ImportResult(False, destination, "already in the library")
+    destination.mkdir(parents=True, exist_ok=True)
 
-    if download.is_file() and download.suffix.lower() in ARCHIVE_SUFFIXES:
-        with zipfile.ZipFile(download) as archive, \
-                archive.open(chosen) as src, \
-                open(destination, "wb") as dst:
-            shutil.copyfileobj(src, dst)
-    else:
-        source = download if download.is_file() else download / chosen
-        shutil.copy2(source, destination)
+    # Members are flattened to their base names. `pick_rom_set` only ever
+    # returns members from one directory, so nothing is lost -- and a set
+    # written by base name cannot traverse out of the directory it was given,
+    # which makes the sidecar path safe by construction rather than by check.
+    written: dict[str, str] = {}
+    for member in chosen.members:
+        name = Path(member.replace("\\", "/")).name
+        if not is_safe_name(name, destination):
+            log.warning("refusing set member with an unusable name: %r", member)
+            continue
+        if name in written:
+            return ImportResult(
+                False, destination,
+                f"two files in this download are both called {name!r} "
+                f"({written[name]} and {member}); refusing to guess which "
+                "one the game needs")
+        source.copy(member, destination / name)
+        written[name] = member
 
-    log.info("imported %s -> %s", chosen, destination)
+    log.info("imported %d files -> %s", len(written), destination)
     return ImportResult(True, destination)
+
+
+def _set_name(primary: str) -> str:
+    """The directory name a multi-file game gets.
+
+    The primary's stem, because that is the name the sheet carries and the one
+    a person recognises. `102 Dalmatians ….gdi` and its five `trackNN.bin`
+    files become `102 Dalmatians …/`.
+    """
+    return Path(primary.replace("\\", "/")).stem
 
 
 def map_remote_path(path, mappings):

--- a/romarr/library.py
+++ b/romarr/library.py
@@ -221,7 +221,15 @@ class MissingArchiveTool(Exception):
     """The download is in a format no installed tool can open."""
 
 
-def _source_for(download: Path) -> _Source:
+def _source_for(download: Path, platform: Platform | None = None) -> _Source:
+    # For MAME, FBNeo and DOSBox the archive IS the ROM: the core opens it and
+    # expects its internal layout. Looking inside would pick one chip dump out
+    # of a romset and import that, which succeeds and leaves an entry no core
+    # can load. Treat it as a plain file.
+    if (platform is not None and platform.archive_is_the_rom
+            and download.is_file()):
+        return _PathSource(download)
+
     suffix = download.suffix.lower()
     if download.is_file() and suffix in _STDLIB_ARCHIVES:
         return _ZipSource(download)
@@ -265,7 +273,7 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
             "Management.")
 
     try:
-        source = _source_for(download)
+        source = _source_for(download, platform)
         candidates = source.names()
     except MissingArchiveTool as exc:
         return ImportResult(False, None, str(exc))

--- a/romarr/platforms.py
+++ b/romarr/platforms.py
@@ -13,7 +13,22 @@ readmes, box art, and sometimes several regional dumps in one archive.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+
+
+#: What kind of medium a game shipped on. This is not decoration: it decides
+#: the magnitude of the size ceiling, the wording when a release is rejected
+#: for size, and -- the part that actually mattered -- whether one file is a
+#: complete game or the first of several.
+#:
+#: A cartridge dump is one file. A disc rip is a `.cue` naming `.bin` tracks,
+#: or a `.gdi` naming five of them, and importing the sheet alone produces a
+#: library entry that looks correct and boots nothing. `selection.pick_rom_set`
+#: exists because of this field.
+CARTRIDGE = "cartridge"
+DISC = "disc"
+COMPUTER = "computer"
 
 
 @dataclass(frozen=True)
@@ -26,9 +41,25 @@ class Platform:
     aliases: tuple[str, ...] = field(default=())
     # The largest plausible download for ONE game on this system. See MB below.
     max_size: int = 32 * 1024 * 1024
+    media: str = CARTRIDGE
+    # Words in FOREIGN_PLATFORM_MARKERS that are native here, and so must not
+    # disqualify a release.
+    #
+    # The marker list is shared, and a marker that names another system for
+    # fifteen platforms can name *this* one for the sixteenth. "wad" is the
+    # case that forced this: it is the marker that catches a Wii Virtual
+    # Console repackage of a Genesis game, and it is also the extension every
+    # legitimate WiiWare title ships as. Without an exemption, adding Wii as a
+    # platform would have made most of its catalogue unrequestable.
+    native_markers: tuple[str, ...] = field(default=())
+
+    @property
+    def is_disc(self) -> bool:
+        return self.media == DISC
 
 
 MB = 1024 * 1024
+GB = 1024 * MB
 
 # How big a release for each system can plausibly be.
 #
@@ -40,8 +71,8 @@ MB = 1024 * 1024
 # Each number is the biggest cartridge the system shipped, rounded up hard for
 # headroom, because a release is not always a bare ROM: it may be zipped, carry
 # box art and a readme, or hold several regional dumps. The headroom is what
-# makes this safe to tighten -- the job is to exclude disc images and PC ports,
-# not to second-guess how a dump was packaged.
+# makes this safe to tighten -- the job is to exclude PC ports and romsets, not
+# to second-guess how a dump was packaged.
 #
 #   system   biggest cartridge          ceiling here
 #   NES      1MB   (mapper-heavy carts)  8MB
@@ -49,6 +80,21 @@ MB = 1024 * 1024
 #   GBA      32MB  (full 256Mbit carts)  128MB
 #   N64      64MB  (Resident Evil 2)     256MB
 #   Genesis  8MB   (Pier Solar)          32MB
+#
+# Disc ceilings follow the same rule one medium up: the capacity of the disc,
+# rounded for a rip that may carry uncompressed audio tracks. They still do
+# real work -- a 12GB PS2 ceiling is what keeps a 60GB PC repack out of a PS2
+# request, which is the same job the 24MB SNES ceiling does against a 452MB PC
+# build.
+#
+#   system   disc capacity              ceiling here
+#   PSX      700MB (CD)                  2GB
+#   Saturn   700MB (CD)                  2GB
+#   Dreamcast 1.2GB (GD-ROM)             3GB
+#   GameCube 1.5GB (miniDVD)             4GB
+#   PSP      1.8GB (UMD)                 4GB
+#   PS2      8.5GB (dual-layer DVD)      12GB
+#   Wii      8.5GB (dual-layer DVD)      12GB
 PLATFORMS: tuple[Platform, ...] = (
     Platform("nes", "Nintendo Entertainment System", (".nes", ".fds", ".unf"),
              ("nintendo", "famicom", "nintendo entertainment system"),
@@ -80,6 +126,89 @@ PLATFORMS: tuple[Platform, ...] = (
     Platform("wonderswan", "WonderSwan", (".ws", ".wsc"), (), max_size=16 * MB),
     Platform("neo-geo-pocket", "Neo Geo Pocket", (".ngp", ".ngc"), (), max_size=8 * MB),
     Platform("virtualboy", "Virtual Boy", (".vb",), ("virtual boy",), max_size=8 * MB),
+
+    # -- large cartridges ---------------------------------------------------
+    #
+    # Excluded before for the same reason discs were, and just as wrongly: a
+    # DS cartridge is 512MB at the very most and EmulatorJS runs `melonds` for
+    # it out of the box.
+    Platform("nds", "Nintendo DS", (".nds", ".dsi", ".ids"),
+             ("nintendo ds", "ds"), max_size=512 * MB),
+    Platform("3ds", "Nintendo 3DS", (".3ds", ".cci", ".cxi", ".cia"),
+             ("nintendo 3ds", "3ds"), max_size=8 * GB),
+
+    # -- optical media ------------------------------------------------------
+    #
+    # Extension order is preference order, and for a disc that ordering is a
+    # correctness rule rather than a taste: a `.chd` or `.rvz` is ONE file that
+    # cannot be separated from its tracks, while a `.cue` is a text file that
+    # is worthless without the `.bin` beside it. Preferring the whole-disc
+    # image makes the fragile case the fallback rather than the default.
+    #
+    # `.cue` and `.bin` are always declared together. A platform that named
+    # the sheet without the tracks would import a pointer to nothing --
+    # `test_a_cue_never_appears_without_its_bin` fails if that is ever
+    # narrowed.
+    Platform("psx", "Sony PlayStation",
+             (".chd", ".pbp", ".cue", ".bin", ".img", ".ccd", ".iso", ".m3u"),
+             ("playstation", "sony playstation", "ps1", "psone", "psx"),
+             max_size=2 * GB, media=DISC),
+    Platform("ps2", "Sony PlayStation 2",
+             (".chd", ".iso", ".cso", ".bin", ".gz"),
+             ("playstation 2", "sony playstation 2", "ps2"),
+             max_size=12 * GB, media=DISC),
+    Platform("psp", "Sony PlayStation Portable",
+             (".cso", ".iso", ".chd", ".pbp"),
+             ("playstation portable", "psp"),
+             max_size=4 * GB, media=DISC),
+    Platform("saturn", "Sega Saturn",
+             (".chd", ".cue", ".bin", ".iso", ".ccd", ".mds"),
+             ("sega saturn",), max_size=2 * GB, media=DISC),
+    Platform("segacd", "Sega CD / Mega-CD",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("sega cd", "mega cd", "megacd", "mega-cd", "sega mega-cd"),
+             max_size=2 * GB, media=DISC),
+    Platform("dc", "Sega Dreamcast",
+             (".chd", ".gdi", ".cdi", ".cue", ".bin"),
+             ("dreamcast", "sega dreamcast"), max_size=3 * GB, media=DISC),
+    Platform("ngc", "Nintendo GameCube",
+             (".rvz", ".iso", ".gcm", ".ciso", ".gcz"),
+             ("gamecube", "nintendo gamecube", "game cube", "gcn"),
+             max_size=4 * GB, media=DISC),
+    Platform("wii", "Nintendo Wii",
+             (".rvz", ".wbfs", ".iso", ".wad", ".ciso", ".gcz"),
+             ("nintendo wii",), max_size=12 * GB, media=DISC,
+             # See Platform.native_markers. Every Wii release that is a
+             # WiiWare or Virtual Console title says so, and those are the
+             # markers that exist to catch such a title being offered for a
+             # *cartridge* platform. Here they are the catalogue.
+             native_markers=("wad", "wiiware", "virtual console", "eshop")),
+    Platform("3do", "3DO Interactive Multiplayer",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("3do interactive", "panasonic 3do"), max_size=2 * GB, media=DISC),
+    Platform("philips-cd-i", "Philips CD-i",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("cd-i", "cdi", "philips cdi"), max_size=2 * GB, media=DISC),
+    Platform("pc-fx", "NEC PC-FX",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("pcfx", "nec pc-fx"), max_size=2 * GB, media=DISC),
+    # RomM has two slugs for this machine. This is the one the live library
+    # materialises and the one `RommStreamServer/tiers.py` routes, so it is the
+    # one that can actually be filed into and played.
+    Platform("turbografx-16-slash-pc-engine-cd", "TurboGrafx-CD / PC Engine CD",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("turbografx cd", "turbografx-cd", "pc engine cd", "pcecd",
+              "super cd-rom"),
+             max_size=2 * GB, media=DISC),
+    Platform("amiga-cd32", "Amiga CD32",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("cd32", "amiga cd32"), max_size=2 * GB, media=DISC),
+    Platform("neo-geo-cd", "Neo Geo CD",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("neogeo cd", "neo geo cd"), max_size=2 * GB, media=DISC),
+    Platform("atari-jaguar-cd", "Atari Jaguar CD",
+             (".chd", ".cue", ".bin", ".iso"),
+             ("jaguar cd",), max_size=2 * GB, media=DISC),
 )
 
 _BY_SLUG = {p.slug: p for p in PLATFORMS}
@@ -120,13 +249,41 @@ def resolve(text: str) -> Platform | None:
             if label == needle:
                 return platform
             start = needle.find(label)
-            if start >= 0:
+            if start >= 0 and not _leaves_a_model_number(needle, start + len(label)):
                 candidates.append((start, -len(label), platform))
 
     if not candidates:
         return None
     candidates.sort()
     return candidates[0][2]
+
+
+# A model number left over after a partial alias match, e.g. the "5" in
+# "playstation 5" once "playstation" has matched.
+_MODEL_NUMBER = re.compile(r"\s*\d")
+
+
+def _leaves_a_model_number(needle: str, end: int) -> bool:
+    """Whether a partial match leaves a digit that names a different machine.
+
+    Console families number their successors, so a partial match on the family
+    name is the *most* dangerous kind: "playstation" is inside "playstation 2",
+    "playstation 3", "playstation 4" and "playstation 5" alike, and the
+    position-ranked match that correctly picks SNES out of "super nintendo
+    entertainment system" happily answers a PlayStation 5 request with a
+    PlayStation 1 folder.
+
+    An exact alias is unaffected -- `resolve` returns those before it gets
+    here, which is how "playstation 2" still reaches the PS2 row. What this
+    rejects is only the case where an alias matched a prefix and the part it
+    did not match begins with a number. That is never a decoration; it is the
+    generation.
+
+    Trailing words are deliberately still allowed. "super nintendo
+    entertainment system" has to keep working, and no console family
+    distinguishes its generations by a trailing word alone.
+    """
+    return _MODEL_NUMBER.match(needle, end) is not None
 
 
 def platform_for_file(filename: str) -> Platform | None:

--- a/romarr/platforms.py
+++ b/romarr/platforms.py
@@ -52,6 +52,15 @@ class Platform:
     # legitimate WiiWare title ships as. Without an exemption, adding Wii as a
     # platform would have made most of its catalogue unrequestable.
     native_markers: tuple[str, ...] = field(default=())
+    # Whether an archive IS the ROM here rather than something to look inside.
+    #
+    # For MAME and FBNeo the `.zip` is the romset: the core opens it itself and
+    # expects its internal layout of chip dumps. Extracting one produces a
+    # directory of `.u1`/`.c1`/`.v1` files that no core can load, so the import
+    # would "succeed" and leave an unplayable entry. `RommStreamServer` has the
+    # same rule in `archives.py` under the same reasoning -- extraction is
+    # opt-in per platform, never "expand anything compressed".
+    archive_is_the_rom: bool = False
 
     @property
     def is_disc(self) -> bool:
@@ -96,11 +105,16 @@ GB = 1024 * MB
 #   PS2      8.5GB (dual-layer DVD)      12GB
 #   Wii      8.5GB (dual-layer DVD)      12GB
 PLATFORMS: tuple[Platform, ...] = (
+    # "famicom" and "super famicom" were aliases here until those became
+    # platforms in their own right. RomM keeps separate folders for them and
+    # the live library fills both -- 106 famicom, 968 fds, 127 sfam -- so a
+    # request naming the Japanese machine now reaches the Japanese folder
+    # instead of being filed under its western twin.
     Platform("nes", "Nintendo Entertainment System", (".nes", ".fds", ".unf"),
-             ("nintendo", "famicom", "nintendo entertainment system"),
+             ("nintendo", "nintendo entertainment system"),
              max_size=8 * MB),
     Platform("snes", "Super Nintendo", (".smc", ".sfc", ".swc", ".fig"),
-             ("super nintendo", "super famicom", "sfc", "super nes"),
+             ("super nintendo", "sfc", "super nes"),
              max_size=24 * MB),
     Platform("gb", "Game Boy", (".gb",), ("gameboy", "game boy"),
              max_size=8 * MB),
@@ -209,6 +223,92 @@ PLATFORMS: tuple[Platform, ...] = (
     Platform("atari-jaguar-cd", "Atari Jaguar CD",
              (".chd", ".cue", ".bin", ".iso"),
              ("jaguar cd",), max_size=2 * GB, media=DISC),
+
+    # -- everything else with a player --------------------------------------
+    #
+    # Extensions and ceilings below are read off the live library rather than
+    # recalled: the counts came from sampling each platform's folder, so
+    # `.a52` is here because 320 Atari 5200 files end in it and `.col` because
+    # 172 ColecoVision ones do.
+    #
+    # The bar for inclusion is a real play route -- a core in RomM's base
+    # EmulatorJS map, or one installed on the stream server. Every platform
+    # here has one, and together they were 17,000-odd games in the library
+    # that ROMarr had no way to request.
+    Platform("jaguar", "Atari Jaguar",
+             (".jag", ".j64", ".rom", ".abs", ".cof", ".prg"),
+             ("atari jaguar",), max_size=32 * MB),
+    # For MAME and FBNeo the zip is the romset, not a container -- see
+    # Platform.archive_is_the_rom.
+    Platform("arcade", "Arcade", (".zip", ".7z", ".chd"),
+             ("mame", "coin-op"), max_size=256 * MB,
+             archive_is_the_rom=True),
+    Platform("neogeoaes", "Neo Geo AES", (".zip", ".7z"),
+             ("neo geo aes", "neogeo aes"), max_size=256 * MB,
+             archive_is_the_rom=True),
+    Platform("neogeomvs", "Neo Geo MVS", (".zip", ".7z"),
+             ("neo geo mvs", "neogeo mvs"), max_size=256 * MB,
+             archive_is_the_rom=True),
+    Platform("atari5200", "Atari 5200", (".a52", ".bin"), ("5200",),
+             max_size=8 * MB),
+    Platform("colecovision", "ColecoVision", (".col", ".rom", ".bin", ".zip"),
+             ("coleco",), max_size=8 * MB),
+    Platform("sega32", "Sega 32X", (".32x", ".bin", ".zip"),
+             ("32x", "sega 32x", "mega 32x"), max_size=32 * MB),
+    Platform("supergrafx", "PC Engine SuperGrafx", (".sgx", ".pce", ".zip"),
+             ("super grafx",), max_size=16 * MB),
+    Platform("vectrex", "Vectrex", (".vec", ".bin", ".zip"), (),
+             max_size=8 * MB),
+    Platform("intellivision", "Intellivision", (".int", ".rom", ".bin", ".zip"),
+             ("intv",), max_size=8 * MB),
+    Platform("wonderswan-color", "WonderSwan Color", (".wsc", ".zip"),
+             ("wonderswan colour",), max_size=16 * MB),
+    Platform("neo-geo-pocket-color", "Neo Geo Pocket Color", (".ngc", ".ngp"),
+             ("neo geo pocket colour", "ngpc"), max_size=16 * MB),
+    # Regional twins of platforms already here. They are separate RomM folders
+    # with their own catalogues -- 968 fds, 127 sfam, 106 famicom -- so a
+    # request for one must not be filed under the other.
+    Platform("fds", "Famicom Disk System", (".fds", ".zip"),
+             ("famicom disk system", "disk system"), max_size=8 * MB),
+    Platform("famicom", "Famicom", (".nes", ".zip"), (), max_size=8 * MB),
+    Platform("sfam", "Super Famicom", (".sfc", ".smc", ".zip"), (),
+             max_size=24 * MB),
+
+    # -- home computers -----------------------------------------------------
+    #
+    # Disk images, not cartridges, and often several per title -- which is why
+    # `.m3u` is declared where the library actually uses it (99 of the Sharp
+    # X68000 entries).
+    Platform("c64", "Commodore 64",
+             (".d64", ".t64", ".d81", ".tap", ".prg", ".crt", ".zip"),
+             ("commodore 64", "c 64"), max_size=16 * MB, media=COMPUTER),
+    Platform("c128", "Commodore 128", (".d64", ".d81", ".t64", ".prg"),
+             ("commodore 128",), max_size=16 * MB, media=COMPUTER),
+    Platform("vic-20", "Commodore VIC-20", (".prg", ".d64", ".t64", ".crt"),
+             ("vic 20", "vic20"), max_size=16 * MB, media=COMPUTER),
+    Platform("amiga", "Commodore Amiga",
+             (".adf", ".hdf", ".ipf", ".lha", ".zip"),
+             ("commodore amiga",), max_size=512 * MB, media=COMPUTER),
+    Platform("acpc", "Amstrad CPC", (".dsk", ".sna", ".cdt", ".zip"),
+             ("amstrad cpc", "cpc"), max_size=32 * MB, media=COMPUTER),
+    Platform("zxs", "Sinclair ZX Spectrum",
+             (".tzx", ".tap", ".z80", ".sna", ".zip"),
+             ("zx spectrum", "spectrum", "speccy"),
+             max_size=16 * MB, media=COMPUTER),
+    Platform("msx", "MSX", (".rom", ".cas", ".dsk", ".mx1", ".zip"), (),
+             max_size=32 * MB, media=COMPUTER),
+    Platform("msx2", "MSX2", (".rom", ".dsk", ".mx2", ".zip"), (),
+             max_size=32 * MB, media=COMPUTER),
+    Platform("sharp-x68000", "Sharp X68000",
+             (".m3u", ".dim", ".xdf", ".d88", ".zip"),
+             ("x68000", "sharp x 68000"), max_size=256 * MB, media=COMPUTER),
+    Platform("dos", "MS-DOS", (".dosz", ".zip", ".dos", ".img", ".chd"),
+             ("ms-dos", "ms dos", "pc dos"), max_size=2 * GB, media=COMPUTER,
+             archive_is_the_rom=True,
+             # `dos` and `pc` are in FOREIGN_PLATFORM_MARKERS because they mean
+             # "this is a PC port" for every console. Here they are the
+             # platform.
+             native_markers=("dos", "pc", "windows")),
 )
 
 _BY_SLUG = {p.slug: p for p in PLATFORMS}

--- a/romarr/playability.py
+++ b/romarr/playability.py
@@ -1,0 +1,384 @@
+"""How a platform will play, answered before the grab rather than after.
+
+A ROM filed under a platform with no route is *imported but dead*: it appears
+in the library, it has a cover, it has metadata, and clicking it does nothing.
+Nothing about the library afterwards says why. ROMarr could not say anything
+about this at all, which is how the README came to claim that disc platforms
+"cannot be streamed into a browser emulator" while nine of them shipped with
+EmulatorJS cores in stock RomM.
+
+**Four routes, and the fourth is not a failure.**
+
+  * ``local``    -- EmulatorJS, in the browser, from the library server itself.
+  * ``stream``   -- the headless RetroArch stream server, rendering server-side
+                    and delivering video. This is how the machines EmulatorJS
+                    has no core for are played.
+  * ``archive``  -- Archive.org's own in-page emulator. Opening a ``/details/``
+                    page *is* playing the game there.
+  * ``download`` -- always available. A ROM in a library is a ROM you can take
+                    away and run on anything, and an operator who asked for
+                    that has been served.
+
+Nothing here refuses an import, and nothing here is allowed to over-claim.
+A platform wrongly reported playable sends somebody to a game that displays
+and does nothing; a platform wrongly reported unplayable costs them a warning
+they did not need. Those are not symmetric, so every table below fails in the
+second direction.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+from .platforms import Platform, resolve
+
+log = logging.getLogger(__name__)
+
+LOCAL = "local"
+STREAM = "stream"
+ARCHIVE = "archive"
+DOWNLOAD = "download"
+
+#: Best first. `download` is last because it is the floor, not because it is
+#: bad -- it is the only route that is always true.
+_ORDER = (LOCAL, STREAM, ARCHIVE, DOWNLOAD)
+
+#: The RomM release `EJS_CORES` was read from.
+#:
+#: Vendored rather than fetched, for the reason `rom-hub` states and this
+#: inherits: RomM publishes no endpoint for its core map, `/api/config` does
+#: not carry it, and the map lives in compiled frontend JavaScript. So it is a
+#: copy, it is dated, and it will go stale -- which is fine as long as it says
+#: which release it is stale relative to.
+ROMM_VERSION = "4.9.2"
+
+#: RomM's `_EJS_CORES_MAP`, restricted to the platforms ROMarr models, keyed by
+#: ROMarr's slug.
+#:
+#: **Nine of these are optical systems**, which is the entire factual basis for
+#: removing the disc exclusion: psx, psp, saturn, segacd, 3do, philips-cd-i,
+#: pc-fx, turbografx-cd and amiga-cd32 play in a browser on a stock RomM, with
+#: no configuration and no stream server.
+#:
+#: Two ROMarr slugs are not keys in RomM's map and are covered by a key naming
+#: the same machine -- `genesis-slash-megadrive` by `genesis`,
+#: `turbografx-16-slash-pc-engine-cd` by `turbografx-cd`. That equivalence is
+#: recorded here rather than acted on anywhere else: this module *reports*, and
+#: re-filing a ROM under a neighbouring slug is a different and much worse idea
+#: than telling somebody which core will run it.
+EJS_CORES: dict[str, tuple[str, ...]] = {
+    # -- cartridges ---------------------------------------------------------
+    "nes": ("fceumm", "nestopia"),
+    "snes": ("snes9x",),
+    "gb": ("gambatte", "mgba"),
+    "gbc": ("gambatte", "mgba"),
+    "gba": ("mgba",),
+    "n64": ("mupen64plus_next", "parallel_n64"),
+    "genesis-slash-megadrive": ("genesis_plus_gx",),   # RomM key: `genesis`
+    "sms": ("genesis_plus_gx",),
+    "gamegear": ("genesis_plus_gx",),
+    "atari2600": ("stella2014",),
+    "atari7800": ("prosystem",),
+    "lynx": ("handy",),
+    "turbografx16--1": ("mednafen_pce",),              # RomM key: `tg16`
+    "wonderswan": ("mednafen_wswan",),
+    "neo-geo-pocket": ("mednafen_ngp",),
+    "virtualboy": ("beetle_vb",),
+    "nds": ("melonds", "desmume", "desmume2015"),
+    # -- optical ------------------------------------------------------------
+    "psx": ("pcsx_rearmed", "mednafen_psx_hw"),
+    "psp": ("ppsspp",),
+    "saturn": ("yabause",),
+    "segacd": ("genesis_plus_gx", "picodrive"),
+    "3do": ("opera",),
+    "philips-cd-i": ("same_cdi",),
+    "pc-fx": ("mednafen_pcfx",),
+    "turbografx-16-slash-pc-engine-cd": ("mednafen_pce",),  # RomM: turbografx-cd
+    "amiga-cd32": ("puae",),
+}
+
+#: Deliberately absent from the table above, and why, so that "we checked"
+#: cannot decay into "nobody looked". Each was confirmed to have no core in
+#: RomM 4.9.2's base map and no other slug in that map covering the same
+#: machine. They are not dead ends -- `ps2`, `ngc`, `wii`, `dc` and `3ds` all
+#: play on the stream tier -- they simply do not play in a browser.
+NO_EJS_CORE: dict[str, str] = {
+    "ps2": "EmulatorJS ships no PlayStation 2 core; PCSX2 is server-side only",
+    "ngc": "EmulatorJS ships no GameCube core; Dolphin is server-side only",
+    "wii": "EmulatorJS ships no Wii core; Dolphin is server-side only",
+    "dc": "EmulatorJS ships no Dreamcast core; flycast is server-side only",
+    "3ds": "azahar is in RomM's nightly cores, which need netplay enabled",
+    "neo-geo-cd": "no Neo Geo CD core in RomM's map or on the stream server",
+    "atari-jaguar-cd": "no Jaguar CD core in RomM's map or on the stream server",
+}
+
+#: When ARCHIVE_EMULATED was measured, and against what.
+#:
+#: Archive.org records the emulator for an item in its `emulator` metadata
+#: field -- 272,424 items carry one -- so this is their data, not an estimate.
+#: Counts came from `advancedsearch.php?q=emulator:"<driver>"`.
+ARCHIVE_MEASURED_ON = "2026-08-02"
+
+#: Platforms Archive.org's in-page emulator actually runs, with the item count
+#: behind each.
+#:
+#: **The disc systems are absent and that is the finding, not an omission.**
+#: The drivers return nothing: `psj`/`psu`/`pse` 0 items, `saturn` 0, `3do` 0,
+#: `dc` 2, `segacd` 1. Archive.org is a *source* for disc images and not a
+#: player of them, so offering this route for a PlayStation request would send
+#: an operator to a details page with a download button and no emulator.
+ARCHIVE_EMULATED: dict[str, int] = {
+    "genesis-slash-megadrive": 12877,   # drivers `genesis` + `megadriv`
+    "atari2600": 3123,
+    "nes": 514,
+    "snes": 538,
+    "gbc": 553,
+    "gb": 553,
+    "gba": 483,
+    "n64": 8,
+}
+
+#: How long to wait on a stream server. It is a LAN service answering out of an
+#: in-memory table, and one that is down must not hold up a page.
+STREAM_TIMEOUT = 5.0
+
+#: The one endpoint this module calls. A GET that reads a routing table: it
+#: allocates no display, starts no emulator and creates no session.
+PLAY_ROUTE_PATH = "/api/play/route"
+
+
+@dataclass(frozen=True)
+class Route:
+    """One way this platform can be played."""
+
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class Playability:
+    """Every route open to one platform, best first."""
+
+    platform: str
+    routes: tuple[Route, ...]
+    #: Set when a stream server was configured and could not be reached, so
+    #: the absence of a stream route can be told apart from a refusal.
+    stream_unreachable: str = ""
+
+    @property
+    def kinds(self) -> tuple[str, ...]:
+        return tuple(r.kind for r in self.routes)
+
+    @property
+    def plays_without_downloading(self) -> bool:
+        """Whether somebody can press play and have a game start.
+
+        The honest question, and the reason `download` is not counted: taking
+        a 4GB image away to run it elsewhere is a real answer to "can I have
+        this", and not an answer to "can I play this here".
+        """
+        return any(r.kind != DOWNLOAD for r in self.routes)
+
+    def summary(self) -> str:
+        """One line for a UI, an API field or a log."""
+        parts = [f"{self.platform}:"]
+        parts.extend(r.detail for r in self.routes)
+        if self.stream_unreachable:
+            parts.append(f"(stream server unreachable: {self.stream_unreachable})")
+        return " ".join(parts)
+
+
+def routes_for(platform, *, stream=None) -> Playability:
+    """How `platform` will play. Accepts a `Platform` or any name that resolves.
+
+    `stream` is an optional object with `.tier(slug) -> str | None`, normally a
+    `StreamServer`. It is asked last and trusted first: it is the only source
+    that knows which cores are actually installed on the operator's own
+    machine, while the tables here know only what the software ships with.
+    """
+    if isinstance(platform, Platform):
+        resolved, name, slug = platform, platform.name, platform.slug
+    else:
+        resolved = resolve(str(platform or ""))
+        slug = resolved.slug if resolved else str(platform or "")
+        name = resolved.name if resolved else slug
+
+    found: dict[str, Route] = {}
+    unreachable = ""
+
+    cores = EJS_CORES.get(slug)
+    if cores:
+        found[LOCAL] = Route(
+            LOCAL,
+            f"plays in the browser on EmulatorJS ({', '.join(cores)})")
+
+    if stream is not None:
+        tier = None
+        try:
+            tier = stream.tier(slug)
+        except Exception as exc:            # a LAN service being down is normal
+            log.warning("stream server did not answer for %r: %s", slug, exc)
+            unreachable = str(exc)
+        if not unreachable and not getattr(stream, "reachable", True):
+            unreachable = "no answer"
+        where = getattr(stream, "label", "the stream server")
+        if tier == STREAM:
+            found[STREAM] = Route(
+                STREAM,
+                f"streams server-side from {where} (headless RetroArch)")
+        elif tier == LOCAL and LOCAL not in found:
+            # The server distinguishes the tiers, and so must this: reporting
+            # "streamed server-side" for something the browser runs is a lie
+            # about where the work happens.
+            found[LOCAL] = Route(
+                LOCAL, f"plays in the browser on EmulatorJS (per {where})")
+
+    if slug in ARCHIVE_EMULATED:
+        found[ARCHIVE] = Route(
+            ARCHIVE,
+            f"plays in the page on Archive.org "
+            f"({ARCHIVE_EMULATED[slug]:,} emulated items)")
+
+    if LOCAL not in found and STREAM not in found:
+        # Prefer the stream server's own words when it gave any.
+        #
+        # It knows things this module cannot: which cores are installed, and
+        # whether the firmware they need is present. Without that, a platform
+        # whose core is installed but BIOS-less reads "configure a stream
+        # server to play it here" to an operator who has already configured
+        # one -- pointing at the wrong fix, and hiding the one that works.
+        # That is the same firmware gate that exists because a core with no
+        # BIOS does not fail loudly: it draws an error screen and streams it
+        # at a perfectly healthy 30fps.
+        served = _stream_reason(stream, slug) if stream is not None else ""
+        if served:
+            detail = f"download only -- {served}"
+        else:
+            reason = NO_EJS_CORE.get(slug, "no browser core for this platform")
+            detail = (f"download only -- {reason}; configure a stream server "
+                      "to play it here")
+        found[DOWNLOAD] = Route(DOWNLOAD, detail)
+    else:
+        found[DOWNLOAD] = Route(DOWNLOAD, "downloadable")
+
+    ordered = tuple(found[k] for k in _ORDER if k in found)
+    return Playability(name, ordered, stream_unreachable=unreachable)
+
+
+def _stream_reason(stream, slug: str) -> str:
+    """The stream server's own explanation, if it offered one."""
+    why = getattr(stream, "why", None)
+    if not callable(why):
+        return ""
+    try:
+        return str(why(slug) or "")
+    except Exception:
+        return ""
+
+
+class StreamServer:
+    """Read-only client for a headless RetroArch stream server's routing.
+
+    One endpoint, one question: could this server play this platform, and on
+    which tier. It has no method that starts anything -- the session routes
+    take a ROM name that must resolve inside the server's own directory, so
+    there is nothing here for ROMarr to hand them anyway.
+
+    Answers are cached for the process lifetime. The routing table is built
+    from what is installed on disk, which does not change while the server is
+    up, and a Library page must not make one HTTP call per row.
+
+    **A server that is down stops being asked**, which is not an optimisation.
+    Only successful answers are cached -- a failure must not be remembered as
+    "cannot play this" -- so without a breaker the first status page after the
+    stream server goes down makes one timing-out request per platform. At
+    thirty-odd platforms and a five-second timeout that is nearly three
+    minutes of hanging page for a service that is optional. Measured at 69
+    seconds before this existed.
+    """
+
+    #: How long to stop asking after a failure. Long enough that a down server
+    #: costs one timeout per page rather than thirty; short enough that a
+    #: restarted one is picked up without restarting ROMarr.
+    DOWN_COOLDOWN = 30.0
+
+    def __init__(self, base_url: str, timeout: float = STREAM_TIMEOUT):
+        self.base_url = (base_url or "").rstrip("/")
+        self.timeout = timeout
+        self._cache: dict[str, str | None] = {}
+        self._reachable = True
+        self._problem = ""
+        self._down_until = 0.0
+        self._why: dict[str, str] = {}
+
+    def why(self, slug: str) -> str:
+        """Why this server cannot play `slug`, in its own words.
+
+        The server distinguishes "no core exists", "the core is not installed"
+        and "supply firmware" -- three very different problems for an operator,
+        and only it knows which applies. Blank when it has not been asked, or
+        answered with a tier.
+        """
+        return self._why.get(slug, "")
+
+    @property
+    def label(self) -> str:
+        return self.base_url or "the stream server"
+
+    @property
+    def reachable(self) -> bool:
+        return self._reachable
+
+    def tier(self, slug: str) -> str | None:
+        """"local", "stream", or None when the server cannot play it.
+
+        None is also the answer when the server is unreachable. The caller
+        tells the two apart with `reachable`, because "cannot play this" and
+        "did not answer" lead an operator to different fixes.
+        """
+        if not self.base_url or not slug:
+            return None
+        if slug in self._cache:
+            return self._cache[slug]
+        if time.monotonic() < self._down_until:
+            self._reachable = False
+            return None
+
+        url = (f"{self.base_url}{PLAY_ROUTE_PATH}?"
+               + urllib.parse.urlencode({"platform": slug}))
+        try:
+            with urllib.request.urlopen(url, timeout=self.timeout) as response:
+                body = json.loads(response.read().decode("utf-8"))
+            tier = body.get("tier")
+            tier = tier if isinstance(tier, str) else None
+            self._reachable = True
+        except urllib.error.HTTPError as exc:
+            # 404 is the server's documented "unplayable" answer and is a real
+            # answer, not a failure -- it carries `why`.
+            self._reachable = True
+            tier = None
+            if exc.code == 404:
+                try:
+                    said = json.loads(exc.read().decode("utf-8")).get("why")
+                    if isinstance(said, str) and said:
+                        self._why[slug] = said
+                except Exception:
+                    pass
+            else:
+                self._reachable, self._problem = False, f"HTTP {exc.code}"
+        except Exception as exc:
+            self._reachable, self._problem = False, str(exc)
+            tier = None
+
+        if self._reachable:
+            self._cache[slug] = tier
+            self._down_until = 0.0
+        else:
+            self._down_until = time.monotonic() + self.DOWN_COOLDOWN
+        return tier

--- a/romarr/playability.py
+++ b/romarr/playability.py
@@ -114,8 +114,14 @@ NO_EJS_CORE: dict[str, str] = {
     "wii": "EmulatorJS ships no Wii core; Dolphin is server-side only",
     "dc": "EmulatorJS ships no Dreamcast core; flycast is server-side only",
     "3ds": "azahar is in RomM's nightly cores, which need netplay enabled",
-    "neo-geo-cd": "no Neo Geo CD core in RomM's map or on the stream server",
-    "atari-jaguar-cd": "no Jaguar CD core in RomM's map or on the stream server",
+    "neo-geo-cd": (
+        "EmulatorJS ships no Neo Geo CD core; NeoCD is server-side only "
+        "(fbneo's AES/MVS drivers are cartridge hardware and cannot open a "
+        "cue or a chd)"),
+    "atari-jaguar-cd": (
+        "no emulator plays Jaguar CD. virtualjaguar is the only Jaguar core "
+        "in libretro and declares j64|jag|rom|abs|cof|bin|prg -- cartridges "
+        "only, no cue and no chd"),
 }
 
 #: When ARCHIVE_EMULATED was measured, and against what.
@@ -290,9 +296,14 @@ class StreamServer:
     take a ROM name that must resolve inside the server's own directory, so
     there is nothing here for ROMarr to hand them anyway.
 
-    Answers are cached for the process lifetime. The routing table is built
-    from what is installed on disk, which does not change while the server is
-    up, and a Library page must not make one HTTP call per row.
+    Answers are cached, because a Library page must not make one HTTP call per
+    row. **With a TTL, not for the process lifetime**, which is what it was
+    until installing a core proved the assumption wrong: the routing table is
+    built from what is on disk, and "that does not change while the server is
+    up" is false the moment somebody installs a core and restarts it. Neo Geo
+    CD went from unplayable to streaming and ROMarr kept saying "no emulator
+    exists" until it was restarted, which is a confusing way to be told that
+    your work succeeded.
 
     **A server that is down stops being asked**, which is not an optimisation.
     Only successful answers are cached -- a failure must not be remembered as
@@ -308,10 +319,15 @@ class StreamServer:
     #: restarted one is picked up without restarting ROMarr.
     DOWN_COOLDOWN = 30.0
 
+    #: How long a successful answer is trusted. Short enough that installing a
+    #: core is visible without restarting ROMarr, long enough that browsing
+    #: costs nothing.
+    CACHE_TTL = 300.0
+
     def __init__(self, base_url: str, timeout: float = STREAM_TIMEOUT):
         self.base_url = (base_url or "").rstrip("/")
         self.timeout = timeout
-        self._cache: dict[str, str | None] = {}
+        self._cache: dict[str, tuple[str | None, float]] = {}
         self._reachable = True
         self._problem = ""
         self._down_until = 0.0
@@ -344,8 +360,9 @@ class StreamServer:
         """
         if not self.base_url or not slug:
             return None
-        if slug in self._cache:
-            return self._cache[slug]
+        cached = self._cache.get(slug)
+        if cached is not None and time.monotonic() < cached[1]:
+            return cached[0]
         if time.monotonic() < self._down_until:
             self._reachable = False
             return None
@@ -377,7 +394,7 @@ class StreamServer:
             tier = None
 
         if self._reachable:
-            self._cache[slug] = tier
+            self._cache[slug] = (tier, time.monotonic() + self.CACHE_TTL)
             self._down_until = 0.0
         else:
             self._down_until = time.monotonic() + self.DOWN_COOLDOWN

--- a/romarr/playability.py
+++ b/romarr/playability.py
@@ -101,6 +101,29 @@ EJS_CORES: dict[str, tuple[str, ...]] = {
     "pc-fx": ("mednafen_pcfx",),
     "turbografx-16-slash-pc-engine-cd": ("mednafen_pce",),  # RomM: turbografx-cd
     "amiga-cd32": ("puae",),
+    # -- consoles, handhelds and boards -------------------------------------
+    "jaguar": ("virtualjaguar",),
+    "arcade": ("mame2003", "mame2003_plus", "fbneo",
+               "fbalpha2012_cps1", "fbalpha2012_cps2"),
+    "neogeoaes": ("fbneo",),
+    "neogeomvs": ("fbneo",),
+    "atari5200": ("a5200",),
+    "colecovision": ("gearcoleco",),
+    "sega32": ("picodrive",),
+    "supergrafx": ("mednafen_pce",),
+    "wonderswan-color": ("mednafen_wswan",),
+    "neo-geo-pocket-color": ("mednafen_ngp",),
+    "fds": ("fceumm", "nestopia"),
+    "famicom": ("fceumm", "nestopia"),
+    "sfam": ("snes9x",),
+    # -- home computers -----------------------------------------------------
+    "c64": ("vice_x64sc", "vice_x64"),
+    "c128": ("vice_x128",),
+    "vic-20": ("vice_xvic",),
+    "amiga": ("puae",),
+    "acpc": ("cap32", "crocods"),
+    "zxs": ("fuse",),
+    "dos": ("dosbox_pure",),
 }
 
 #: Deliberately absent from the table above, and why, so that "we checked"
@@ -122,6 +145,17 @@ NO_EJS_CORE: dict[str, str] = {
         "no emulator plays Jaguar CD. virtualjaguar is the only Jaguar core "
         "in libretro and declares j64|jag|rom|abs|cof|bin|prg -- cartridges "
         "only, no cue and no chd"),
+    # Home computers EmulatorJS has no core for. All four run on the stream
+    # tier, and all four want firmware the operator supplies -- which is a
+    # different problem from having no emulator, and is said differently.
+    "msx": "EmulatorJS ships no MSX core; blueMSX is server-side only",
+    "msx2": "EmulatorJS ships no MSX2 core; blueMSX is server-side only",
+    "vectrex": "EmulatorJS ships no Vectrex core; vecx is server-side only",
+    "intellivision": (
+        "freeintv is in RomM's nightly cores, which need netplay enabled; "
+        "the stream server runs it server-side"),
+    "sharp-x68000": (
+        "EmulatorJS ships no X68000 core; px68k is server-side only"),
 }
 
 #: When ARCHIVE_EMULATED was measured, and against what.

--- a/romarr/selection.py
+++ b/romarr/selection.py
@@ -13,7 +13,7 @@ import logging
 import re
 from dataclasses import dataclass
 
-from .platforms import Platform
+from .platforms import DISC, Platform
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +54,24 @@ COMPILATION_MARKERS = (
     "rom set", "complete set", "full set", "no-intro", "nointro", "goodgen",
     "tosec", "redump", "everdrive", "megaset", "mega set", "all games",
 )
+
+# Dump-project names that mean "this dump is correct" on the medium the
+# project actually covers, and "this is their whole set" everywhere else.
+#
+# Redump is the disc-preservation project -- what No-Intro is for cartridges.
+# On a disc release its name is the single most reliable quality signal
+# available, and it was in COMPILATION_MARKERS, which rejects outright. Every
+# correctly-labelled disc dump would have been thrown out and the releases
+# left standing would have been the unlabelled ones: the scorer would have
+# systematically preferred worse dumps, and the reason it gave would have been
+# "a compilation, not a single cartridge".
+#
+# Only the medium's own project is exempted, and only for that medium. A
+# Redump-labelled SNES release really is a set, because Redump does not dump
+# cartridges. `_is_a_set` still rejects "Redump - Sony PlayStation Collection"
+# on the word "collection", which is what actually makes it a set.
+_DUMP_PROJECT_FOR_MEDIUM = {DISC: ("redump",)}
+_DUMP_PROJECT_BONUS = 40
 
 # Words that mean "this is not a plain cartridge dump". Matched as substrings,
 # which is why the stem "translat" is listed rather than "translation": it also
@@ -303,7 +321,8 @@ def judge(release: Release, wanted: str,
     # platform's aliases are removed from the check first, so asking for a Wii
     # game does not disqualify a title that says "Wii".
     if platform is not None:
-        own = {platform.slug.lower(), platform.name.lower(), *platform.aliases}
+        own = {platform.slug.lower(), platform.name.lower(), *platform.aliases,
+               *platform.native_markers}
         own_words = {w for entry in own for w in entry.split()}
         for marker in FOREIGN_PLATFORM_MARKERS:
             if marker in own or marker in own_words:
@@ -327,11 +346,18 @@ def judge(release: Release, wanted: str,
     # the import could not. Whole-word matched, so "Collector" and "Classic
     # Edition" as part of a real game name are untouched.
     if platform is not None:
+        native_projects = _DUMP_PROJECT_FOR_MEDIUM.get(platform.media, ())
         for marker in COMPILATION_MARKERS:
+            if marker in native_projects:
+                continue
             if _mentions(lowered, marker):
                 return Judgement(
                     -250,
-                    verdict=f"a compilation, not a single cartridge ({marker})")
+                    verdict=f"a compilation, not a single game ({marker})")
+        for project in native_projects:
+            if _mentions(lowered, project):
+                add(_DUMP_PROJECT_BONUS, f"a {project.title()} dump")
+                break
 
     # Positive evidence that this really is the requested system. It matters
     # more now that the search casts a wider net: a bare title search returns
@@ -355,15 +381,33 @@ def judge(release: Release, wanted: str,
     # PC build of Final Fantasy III passed it and, being the best-seeded result,
     # was picked for a SNES request.
     if platform is not None:
+        medium = "disc image" if platform.is_disc else "cartridge"
         if release.size > platform.max_size:
             add(-200,
-                f"too big for a {platform.name} cartridge "
+                f"too big for a {platform.name} {medium} "
                 f"({release.size // 1048576}MB, ceiling "
                 f"{platform.max_size // 1048576}MB)")
-        elif release.size < 4 * 1024:
-            add(-200, "too small to be a ROM")
+        elif release.size < _size_floor(platform):
+            # The floor is per medium for the same reason the ceiling is. Four
+            # kilobytes is a real floor for an Atari cartridge and no floor at
+            # all for a disc: a few hundred KB offered for a PlayStation
+            # request is a patch, a cheat file or a lone .cue, and every one of
+            # those imports cleanly and boots nothing.
+            add(-200, f"too small to be a {platform.name} {medium}")
 
     return Judgement(points, tuple(reasons))
+
+
+#: The smallest plausible download, per medium. A CD-based game can genuinely
+#: be small -- some are a few megabytes of data and a lot of silence -- so this
+#: is set to catch a file that is not a disc at all rather than to judge how
+#: much of the disc was used.
+_DISC_FLOOR = 1024 * 1024
+_CARTRIDGE_FLOOR = 4 * 1024
+
+
+def _size_floor(platform: Platform) -> int:
+    return _DISC_FLOOR if platform.is_disc else _CARTRIDGE_FLOOR
 
 
 def score(release: Release, wanted: str, platform: Platform | None = None) -> int:
@@ -384,9 +428,22 @@ def best_release(releases: list[Release], wanted: str,
     ranked = [(s, r) for s, r in ranked if s > 0]
     if not ranked:
         return None
-    # Sort by score, then prefer the smaller file: for cartridge ROMs a bigger
-    # file is almost always a romset or a bad dump, not a better copy.
-    ranked.sort(key=lambda pair: (-pair[0], pair[1].size))
+    # Sort by score, then break the tie on size -- in the direction the medium
+    # calls for.
+    #
+    # For a cartridge, smaller wins: a bigger file at the same score is almost
+    # always a romset or a bad dump, not a better copy.
+    #
+    # For a disc that reasoning inverts. Two rips of the same game differ by
+    # how much of the disc was kept -- audio tracks, video, the lot -- so the
+    # smaller of two PlayStation releases scoring alike is the one with
+    # something missing. The ceiling above already excludes anything that is
+    # too big to be the game at all, so preferring the larger here can only
+    # choose between plausible rips.
+    if platform is not None and platform.is_disc:
+        ranked.sort(key=lambda pair: (-pair[0], -pair[1].size))
+    else:
+        ranked.sort(key=lambda pair: (-pair[0], pair[1].size))
     return ranked[0][1]
 
 

--- a/romarr/selection.py
+++ b/romarr/selection.py
@@ -9,10 +9,13 @@ and RomM imports a readme.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 
 from .platforms import Platform
+
+log = logging.getLogger(__name__)
 
 # Newznab/Torznab categories. 1000-1999 is Console, 4000-4999 is PC; only the
 # console range and the PC-games sub-range are of interest here.
@@ -387,31 +390,273 @@ def best_release(releases: list[Release], wanted: str,
     return ranked[0][1]
 
 
+_EXTRA_SUFFIXES = (
+    ".nfo", ".txt", ".diz", ".sfv", ".jpg", ".jpeg", ".png",
+    ".url", ".md5", ".sha1", ".par2", ".exe", ".bat",
+)
+
+
+def _is_extra(name: str) -> bool:
+    return name.lower().endswith(_EXTRA_SUFFIXES)
+
+
+@dataclass(frozen=True)
+class RomSet:
+    """Every file that has to be imported for one game to work.
+
+    A cartridge is a set of one and always was. A disc is not, and treating it
+    as one is the quietest way to break a library: a `.cue` is a few hundred
+    bytes of text naming tracks, so importing it alone produces an entry with a
+    title, a cover, a plausible size and no game. Nothing downstream can tell
+    that apart from a working import -- not the scanner, not the player, not
+    the operator until they press play.
+
+    `primary` is the file an emulator is pointed at. `members` is everything
+    that has to travel with it, `primary` included.
+    """
+
+    primary: str
+    members: tuple[str, ...]
+
+    @property
+    def is_multi_file(self) -> bool:
+        return len(self.members) > 1
+
+
+#: What a sheet names its tracks with. Read out of `SIDECAR_FOR` in
+#: `RommStreamServer/archives.py` rather than derived again here: that table
+#: is already proven against this library, and two copies of the same
+#: knowledge would drift in opposite directions.
+_SIDECAR_FOR: dict[str, tuple[str, ...]] = {
+    ".cue": (".bin", ".img", ".iso"),
+    ".gdi": (".bin", ".raw"),
+    ".ccd": (".img", ".sub"),
+    ".mds": (".mdf",),
+}
+
+#: A playlist binds the discs of one game together. RetroArch and EmulatorJS
+#: both take an `.m3u` as the thing you load for a multi-disc game, so when one
+#: is present it is the primary regardless of what else the release holds --
+#: importing disc one of three is not importing the game.
+_PLAYLIST = ".m3u"
+
+
 def pick_rom_file(filenames: list[str], platform: Platform) -> str | None:
     """Which file in a finished download is the ROM to import.
+
+    Kept for callers that want a single name, and implemented on top of
+    `pick_rom_set` so the two can never disagree about which file is the ROM.
+    """
+    chosen = pick_rom_set(filenames, platform)
+    return chosen.primary if chosen else None
+
+
+def pick_rom_set(filenames: list[str], platform: Platform, *,
+                 read=None) -> RomSet | None:
+    """Which files in a finished download make up the game.
 
     Prefers the platform's own extensions in declared order, then falls back to
     any file that is not obviously an extra. Returns None when the download
     holds nothing playable, which is a real outcome worth reporting rather than
     guessing at.
+
+    `read(name) -> bytes | None` gives access to a sheet's contents. The caller
+    owns it because only the caller knows whether a name is a path on disk or a
+    member of an archive. It is optional: without it the sidecar fallback still
+    produces a complete set, just a more generous one.
     """
     if not filenames:
         return None
 
-    def is_extra(name: str) -> bool:
-        lowered = name.lower()
-        return lowered.endswith(
-            (".nfo", ".txt", ".diz", ".sfv", ".jpg", ".jpeg", ".png",
-             ".url", ".md5", ".sha1", ".par2", ".exe", ".bat")
-        )
+    playable = [f for f in filenames if not _is_extra(f)]
+
+    # A playlist first, and only for a platform that declares it -- an .m3u
+    # beside a SNES rom is somebody else's file.
+    if _PLAYLIST in platform.extensions:
+        playlists = [f for f in playable if f.lower().endswith(_PLAYLIST)]
+        if playlists:
+            primary = sorted(playlists, key=lambda f: (-_region_rank(f), len(f)))[0]
+            listed = _playlist_members(primary, playable, read)
+            return RomSet(primary, (primary, *listed))
 
     for ext in platform.extensions:
-        matches = [f for f in filenames if f.lower().endswith(ext) and not is_extra(f)]
-        if matches:
-            # A multi-dump archive: prefer the region the scorer prefers too.
-            matches.sort(key=lambda f: (-_region_rank(f), len(f)))
-            return matches[0]
+        matches = [f for f in playable if f.lower().endswith(ext)]
+        if not matches:
+            continue
+        # A multi-dump archive: prefer the region the scorer prefers too.
+        matches.sort(key=lambda f: (-_region_rank(f), len(f)))
+        primary = matches[0]
+        sidecars = _sidecars_for(primary, playable, read)
+        return RomSet(primary, (primary, *sidecars))
     return None
+
+
+def _sidecars_for(primary: str, filenames: list[str], read) -> tuple[str, ...]:
+    """The track files `primary` cannot boot without.
+
+    Read out of the sheet where possible. A sheet states its tracks by name,
+    and that is the only source that gets a directory holding two discs right:
+    both cues may say `game.bin`, and each means the one beside it.
+    """
+    ext = _suffix(primary)
+    wanted = _SIDECAR_FOR.get(ext)
+    if not wanted:
+        return ()
+
+    named = _names_in_sheet(primary, read, _cue_and_gdi_names)
+    if named is not None:
+        found = _resolve_beside(primary, named, filenames)
+        if found:
+            return found
+
+    # The sheet could not be read, or named nothing this download holds.
+    #
+    # Deliberately over-inclusive from here. A file too many costs disk; a file
+    # too few costs a game that imports, displays and does not boot -- and the
+    # operator finds out at the point where they have already committed.
+    return _companions(primary, filenames, wanted)
+
+
+def _playlist_members(primary: str, filenames: list[str], read) -> tuple[str, ...]:
+    """The disc images an `.m3u` lists, and their own sidecars.
+
+    A playlist may name `.cue` files rather than whole-disc images, in which
+    case each of those drags its own tracks along -- which is why this recurses
+    through `_sidecars_for` rather than stopping at the names in the file.
+    """
+    named = _names_in_sheet(primary, read, _playlist_names)
+    listed = _resolve_beside(primary, named or (), filenames)
+    if not listed:
+        # No readable playlist: take every disc image beside it. A playlist
+        # with nothing under it is not a game.
+        listed = tuple(f for f in filenames
+                       if f != primary and _same_parent(primary, f)
+                       and _suffix(f) != _PLAYLIST)
+    out: list[str] = []
+    for disc in listed:
+        for name in (disc, *_sidecars_for(disc, filenames, read)):
+            if name not in out:
+                out.append(name)
+    return tuple(out)
+
+
+def _names_in_sheet(primary: str, read, parse) -> tuple[str, ...] | None:
+    """Filenames a sheet refers to, or None when it could not be read.
+
+    None and () mean different things and both are real: None is "no answer
+    available, fall back", () is "the sheet was read and named nothing".
+    """
+    if read is None:
+        return None
+    try:
+        raw = read(primary)
+    except Exception:  # an unreadable member must not end the import
+        log.warning("could not read %r to find its tracks", primary)
+        return None
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="replace")
+    return parse(raw)
+
+
+# `FILE "Track 01.bin" BINARY`, and the unquoted form some writers emit.
+#
+# Every gap is `[ \t]`, never `\s`. `\s` matches a newline, and a sheet is a
+# line-oriented format where that is the difference between reading it and
+# reading through it: a .gdi opens with a bare track count, and `\s+` let the
+# first pattern start on that count, run over the line break, and capture the
+# *sector size* of track one as its filename -- silently dropping track one
+# from every Dreamcast import.
+_CUE_FILE = re.compile(r'^[ \t]*FILE[ \t]+(?:"([^"]+)"|(\S+))',
+                       re.IGNORECASE | re.MULTILINE)
+
+# A gdi track line: index, LBA, type, sector size, filename, offset. The
+# filename is the first field that is not a bare number.
+_GDI_LINE = re.compile(
+    r'^[ \t]*\d+[ \t]+\d+[ \t]+\d+[ \t]+\d+[ \t]+(?:"([^"]+)"|(\S+))',
+    re.MULTILINE)
+
+
+def _cue_and_gdi_names(text: str) -> tuple[str, ...]:
+    out: list[str] = []
+    for pattern in (_CUE_FILE, _GDI_LINE):
+        for match in pattern.finditer(text):
+            name = match.group(1) or match.group(2)
+            if name and name not in out:
+                out.append(name)
+    return tuple(out)
+
+
+def _playlist_names(text: str) -> tuple[str, ...]:
+    """An m3u is one path per line; `#` is a comment."""
+    return tuple(
+        line.strip() for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    )
+
+
+def _resolve_beside(primary: str, named, filenames: list[str]) -> tuple[str, ...]:
+    """Match names from a sheet against what the download actually holds.
+
+    A sheet names its tracks relative to itself, so the match is made within
+    the sheet's own directory. That is the whole reason two discs in one
+    download do not bleed into each other: both sheets may say `game.bin`.
+    """
+    parent = _parent(primary)
+    by_key = {}
+    for f in filenames:
+        if _parent(f) == parent:
+            by_key.setdefault(_basename(f).lower(), f)
+    out: list[str] = []
+    for name in named:
+        got = by_key.get(_basename(name.replace("\\", "/")).lower())
+        if got and got != primary and got not in out:
+            out.append(got)
+    return tuple(out)
+
+
+def _companions(primary: str, filenames: list[str],
+                wanted: tuple[str, ...]) -> tuple[str, ...]:
+    """Track files beside `primary`, when the sheet could not name them.
+
+    Two passes, because the two real layouts need different answers. A
+    download holding several games names each game's tracks after the game
+    ("Game A (Track 01).bin"), so a shared stem is the right filter. A
+    download holding one game names them `track01.bin`, sharing nothing with
+    the sheet -- so when nothing shares the stem, everything beside it is
+    taken.
+    """
+    stem = _stem(primary).lower()
+    beside = [f for f in filenames
+              if f != primary and _same_parent(primary, f)
+              and _suffix(f) in wanted]
+    shared = [f for f in beside if _stem(f).lower().startswith(stem)]
+    return tuple(shared or beside)
+
+
+def _parent(path: str) -> str:
+    normalised = path.replace("\\", "/")
+    return normalised.rsplit("/", 1)[0] if "/" in normalised else ""
+
+
+def _basename(path: str) -> str:
+    normalised = path.replace("\\", "/")
+    return normalised.rsplit("/", 1)[-1]
+
+
+def _stem(path: str) -> str:
+    base = _basename(path)
+    return base.rsplit(".", 1)[0] if "." in base else base
+
+
+def _suffix(path: str) -> str:
+    base = _basename(path)
+    return ("." + base.rsplit(".", 1)[-1]).lower() if "." in base else ""
+
+
+def _same_parent(a: str, b: str) -> bool:
+    return _parent(a) == _parent(b)
 
 
 def _region_rank(name: str) -> int:

--- a/romarr/ui.py
+++ b/romarr/ui.py
@@ -146,8 +146,8 @@ NAV = [
     ("Settings", [("media", "Media Management", None), ("profiles", "Profiles", None),
                   ("indexers", "Indexers", None), ("clients", "Download Clients", None),
                   ("libraries", "Libraries", None), ("general", "General", None)]),
-    ("System",   [("status", "Status", None), ("tasks", "Tasks", None),
-                  ("logs", "Logs", None)]),
+    ("System",   [("status", "Status", None), ("platforms", "Platforms", None),
+                  ("tasks", "Tasks", None), ("logs", "Logs", None)]),
 ]
 
 
@@ -188,7 +188,7 @@ function go(page){
     queue:'Queue',history:'History',media:'Media Management',profiles:'Profiles',
     indexers:'Indexers',clients:'Download Clients',libraries:'Libraries',
     general:'General',
-    status:'System Status',tasks:'Tasks',logs:'Logs',
+    status:'System Status',platforms:'Platforms',tasks:'Tasks',logs:'Logs',
     hub:'ROM Hub — Plugins'};
   $('#top h1').textContent=titles[page]||'ROMarr';
   $('#search').classList.toggle('hide', !['library','add'].includes(page));
@@ -764,13 +764,59 @@ RENDER.status=async()=>{
       ${g.configured?row('GG Requestz',g.ok,g.url)
         :`<tr><td>GG Requestz</td><td><span class="dot"></span>not configured</td>
           <td style="color:var(--dim)">set GGREQUESTZ_URL to show the link</td></tr>`}
+      ${h.stream_url
+        ? row('Stream server',(h.play_routes||{}).stream>0,h.stream_url)
+        : `<tr><td>Stream server</td><td><span class="dot"></span>not configured</td>
+           <td style="color:var(--dim)">set STREAM_SERVER_URL to play PS2, GameCube,
+           Wii, Dreamcast and 3DS here</td></tr>`}
     </tbody></table></div>
+    ${playCard(h.play_routes||{})}
     <div class="card"><h3>About</h3><div class="st">
       <div><b>${esc(h.version)}</b><span>Version</span></div>
       <div><b>${h.platforms}</b><span>Platforms</span></div>
       <div><b>${h.events}</b><span>History events</span></div>
       <div><b>${esc(h.uptime)}</b><span>Uptime</span></div>
     </div></div>`;
+};
+
+// How the supported platforms can actually be played, on THIS install.
+//
+// It belongs on the status page rather than in the docs because the answer
+// depends on the operator's own setup: configuring a stream server moves five
+// platforms out of "download only", and nothing else in the UI would show
+// that it had worked.
+const playCard=r=>`<div class="card"><h3>How platforms play here</h3>
+  <div class="st">
+    <div><b>${r.local||0}</b><span>In the browser (EmulatorJS)</span></div>
+    <div><b>${r.stream||0}</b><span>Streamed (headless RetroArch)</span></div>
+    <div><b>${r.archive||0}</b><span>On Archive.org</span></div>
+    <div><b>${r.download_only||0}</b><span>Download only</span></div>
+  </div>
+  <p class="help">Every platform can be downloaded. ${
+    (r.download_only||0)>0
+      ? `${r.download_only} have no player on this install &mdash; a stream
+         server is what plays PS2, GameCube, Wii, Dreamcast and 3DS.`
+      : 'Every supported platform also plays here without downloading.'}
+    See <a href="#platforms">Platforms</a> for the per-platform answer.</p></div>`;
+
+RENDER.platforms=async()=>{
+  const rows=await j('/api/platforms').catch(()=>[]);
+  const badge=k=>`<span class="pill">${esc(k)}</span>`;
+  $('#page').innerHTML=`<div class="card"><h3>Platforms</h3>
+    <p class="help">What ROMarr can request, and how each one plays on this
+      install. Disc platforms are included: nine of them run in the browser on
+      a stock RomM, and the rest stream from a stream server.</p>
+    <table><thead><tr><th>Platform</th><th>Media</th><th>Plays</th>
+      <th>Ceiling</th><th>Extensions</th></tr></thead><tbody>
+    ${rows.map(p=>`<tr>
+      <td>${esc(p.name)}<div style="color:var(--dim);font-size:12px">${esc(p.slug)}</div></td>
+      <td>${badge(p.media)}</td>
+      <td>${(p.play_routes||[]).map(badge).join(' ')}</td>
+      <td style="white-space:nowrap">${p.max_size_mb>=1024
+          ? (p.max_size_mb/1024).toFixed(0)+' GB' : p.max_size_mb+' MB'}</td>
+      <td style="color:var(--dim);font-size:12px">${esc((p.extensions||[]).join(' '))}</td>
+    </tr>`).join('')}
+    </tbody></table></div>`;
 };
 
 RENDER.tasks=async()=>{

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -174,11 +174,15 @@ def test_every_verb_is_guarded_so_a_crash_is_a_500_not_a_dead_socket():
 
 def test_an_unresolvable_platform_is_reported_rather_than_silently_ignored(tmp_path):
     """A name that resolves to nothing is searched with no platform evidence,
-    which quietly changes what the scores mean. `?platform=psx` should say the
-    name was not recognised -- only cartridge systems are modelled."""
+    which quietly changes what the scores mean, so it has to be said out loud.
+
+    This used to use `psx` as its example of an unmodelled platform. It is
+    modelled now -- that is the point of the disc work -- so the example moved
+    to a console generation nothing in this project can acquire or play.
+    """
     svc = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json")})
-    out = svc.search("Final Fantasy VII", "psx")
-    assert out["unknown_platform"] == "psx"
+    out = svc.search("Astro Bot", "playstation 5")
+    assert out["unknown_platform"] == "playstation 5"
     assert out["platform"] is None
 
     known = svc.search("Super Metroid", "snes")

--- a/tests/test_disc_import.py
+++ b/tests/test_disc_import.py
@@ -243,3 +243,56 @@ def test_a_finished_torrent_directory_imports_as_a_set(tmp_path):
     assert result.ok, result.reason
     assert sorted(p.name for p in result.destination.iterdir()) == [
         "Game (USA).bin", "Game (USA).cue"]
+
+
+# --- an archive is not always a container ----------------------------------
+
+ARCADE = by_slug("arcade")
+DOS = by_slug("dos")
+
+
+def test_an_arcade_romset_is_imported_whole(tmp_path):
+    """For MAME and FBNeo the .zip IS the ROM.
+
+    The core opens it and expects its internal layout of chip dumps. Looking
+    inside picks one `.u1` out of a romset and imports that -- which succeeds,
+    and leaves an entry no core can load. RommStreamServer has the same rule
+    in archives.py for the same reason.
+    """
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "sf2ce.zip",
+             {"sf2ce.03c": b"chip", "sf2ce.04a": b"chip", "sf2ce.05b": b"chip"})
+
+    result = import_rom(downloads / "sf2ce.zip", ARCADE, lib)
+
+    assert result.ok, result.reason
+    assert result.destination == lib / "arcade" / "sf2ce.zip"
+    assert result.destination.is_file()
+    # The romset arrived intact, not unpacked into loose chip dumps.
+    with zipfile.ZipFile(result.destination) as landed:
+        assert sorted(landed.namelist()) == ["sf2ce.03c", "sf2ce.04a", "sf2ce.05b"]
+
+
+def test_a_dos_zip_is_imported_whole(tmp_path):
+    """dosbox_pure loads a .zip directly; unpacking it is the same mistake."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "DOOM.zip", {"DOOM.EXE": b"mz", "DOOM.WAD": b"wad"})
+
+    result = import_rom(downloads / "DOOM.zip", DOS, lib)
+
+    assert result.ok, result.reason
+    assert result.destination.name == "DOOM.zip"
+    assert result.destination.is_file()
+
+
+def test_a_platform_without_the_flag_still_looks_inside(tmp_path):
+    """The flag is opt-in; nothing else changes behaviour."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Zelda.smc": b"rom", "readme.nfo": b"x"})
+
+    result = import_rom(downloads / "g.zip", SNES, lib)
+
+    assert result.destination.name == "Zelda.smc"

--- a/tests/test_disc_import.py
+++ b/tests/test_disc_import.py
@@ -1,0 +1,245 @@
+"""Importing a disc: the whole set lands, or the import fails saying so.
+
+The rule these tests exist for is one line long: a `.cue` must never arrive
+in the library without its `.bin`. Everything else here is in service of it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from romarr import library
+from romarr.library import bsdtar_path, import_rom, list_candidates
+from romarr.platforms import by_slug
+
+PSX = by_slug("psx")
+DC = by_slug("dc")
+SNES = by_slug("snes")
+
+needs_bsdtar = pytest.mark.skipif(
+    bsdtar_path() is None,
+    reason="bsdtar (libarchive) is not installed on this machine")
+
+
+def make_zip(path: Path, members: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    return path
+
+
+def make_7z(path: Path, members: dict[str, bytes], tmp_path: Path) -> Path:
+    staging = tmp_path / "staging"
+    staging.mkdir(exist_ok=True)
+    for name, data in members.items():
+        target = staging / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    subprocess.run(
+        [bsdtar_path(), "--format=7zip", "-cf", str(path), "-C", str(staging)]
+        + list(members),
+        check=True, capture_output=True)
+    return path
+
+
+CUE = b'FILE "Game (USA).bin" BINARY\n  TRACK 01 MODE2/2352\n    INDEX 01 00:00:00\n'
+
+
+# --- the whole point -------------------------------------------------------
+
+def test_a_cue_and_its_bin_both_land(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "game.zip",
+             {"Game (USA).cue": CUE, "Game (USA).bin": b"\x00" * 4096,
+              "readme.nfo": b"hi"})
+
+    result = import_rom(downloads / "game.zip", PSX, lib)
+
+    assert result.ok, result.reason
+    landed = sorted(p.name for p in result.destination.rglob("*") if p.is_file())
+    assert landed == ["Game (USA).bin", "Game (USA).cue"]
+
+
+def test_a_multi_file_set_lands_as_a_directory(tmp_path):
+    """The layout the live library already uses.
+
+    `dc/102 Dalmatians - Puppies to the Rescue (NA, Rev 1.001)/` is a
+    directory holding a .gdi and five track files. This produces the same
+    shape, so a disc imported by ROMarr is indistinguishable from one filed
+    by hand.
+    """
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "d.zip", {
+        "102 Dalmatians.gdi": b"3\n1 0 4 2352 track01.bin 0\n"
+                              b"2 600 0 2352 track02.raw 0\n"
+                              b"3 45000 4 2352 track03.bin 0\n",
+        "track01.bin": b"a" * 512,
+        "track02.raw": b"b" * 512,
+        "track03.bin": b"c" * 512,
+    })
+
+    result = import_rom(downloads / "d.zip", DC, lib)
+
+    assert result.ok, result.reason
+    assert result.destination.is_dir()
+    assert result.destination.parent == lib / "dc"
+    assert sorted(p.name for p in result.destination.iterdir()) == [
+        "102 Dalmatians.gdi", "track01.bin", "track02.raw", "track03.bin"]
+
+
+def test_a_single_file_image_still_lands_as_a_file(tmp_path):
+    """Nothing that worked before becomes a directory."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "s.zip", {"Silent Hill (USA).chd": b"\x00" * 8192})
+
+    result = import_rom(downloads / "s.zip", PSX, lib)
+
+    assert result.ok
+    assert result.destination == lib / "psx" / "Silent Hill (USA).chd"
+    assert result.destination.is_file()
+
+
+def test_a_cartridge_import_is_byte_for_byte_what_it_was(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Zelda.smc": b"rom", "readme.nfo": b"x"})
+
+    result = import_rom(downloads / "g.zip", SNES, lib)
+
+    assert result.ok
+    assert result.destination == lib / "snes" / "Zelda.smc"
+    assert result.destination.read_bytes() == b"rom"
+
+
+# --- archives --------------------------------------------------------------
+
+@needs_bsdtar
+def test_a_7z_of_a_disc_imports(tmp_path):
+    """The live disc library is overwhelmingly .7z -- 2,621 psx entries, and
+    the importer could not open any of them."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_7z(downloads / "g.7z",
+            {"Game (USA).cue": CUE, "Game (USA).bin": b"\x01" * 4096},
+            tmp_path)
+
+    result = import_rom(downloads / "g.7z", PSX, lib)
+
+    assert result.ok, result.reason
+    landed = {p.name: p.read_bytes() for p in result.destination.iterdir()}
+    assert landed["Game (USA).cue"] == CUE
+    assert landed["Game (USA).bin"] == b"\x01" * 4096
+
+
+@needs_bsdtar
+def test_list_candidates_reads_a_7z(tmp_path):
+    make_7z(tmp_path / "a.7z", {"x.chd": b"1", "notes.nfo": b"2"}, tmp_path)
+    assert sorted(list_candidates(tmp_path / "a.7z")) == ["notes.nfo", "x.chd"]
+
+
+def test_an_archive_format_with_no_tool_fails_by_name(tmp_path, monkeypatch):
+    """Never a bare "no ROM found". An operator who is missing a tool has to
+    be told which tool, or the diagnosis is a guess about their download."""
+    monkeypatch.setattr(library, "_bsdtar", lambda: None)
+    library.bsdtar_path.cache_clear()
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    (downloads / "g.7z").write_bytes(b"not really a 7z")
+
+    result = import_rom(downloads / "g.7z", PSX, lib)
+
+    assert not result.ok
+    assert "bsdtar" in result.reason
+    library.bsdtar_path.cache_clear()
+
+
+# --- safety ----------------------------------------------------------------
+
+def test_zip_slip_is_refused(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "evil.zip",
+             {"../../escape.chd": b"x", "Game (USA).chd": b"ok"})
+
+    result = import_rom(downloads / "evil.zip", PSX, lib)
+
+    assert result.ok
+    assert result.destination.name == "Game (USA).chd"
+    assert not (tmp_path / "escape.chd").exists()
+    assert not (lib.parent / "escape.chd").exists()
+
+
+def test_a_traversing_member_cannot_ride_along_as_a_sidecar(tmp_path):
+    """The set is where traversal would be easiest to miss: the primary is
+    checked, and the tracks arrive because a sheet named them."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "e.zip", {
+        "Game.cue": b'FILE "../../escape.bin" BINARY\n',
+        "Game.bin": b"legit",
+    })
+
+    result = import_rom(downloads / "e.zip", PSX, lib)
+
+    assert result.ok, result.reason
+    for p in result.destination.rglob("*"):
+        assert ".." not in str(p)
+    assert not (tmp_path / "escape.bin").exists()
+
+
+def test_nothing_is_overwritten_silently(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "d.zip",
+             {"Game.cue": CUE, "Game (USA).bin": b"new" * 100})
+    first = import_rom(downloads / "d.zip", PSX, lib)
+    assert first.ok
+
+    again = import_rom(downloads / "d.zip", PSX, lib)
+    assert not again.ok
+    assert "already in the library" in again.reason
+
+    forced = import_rom(downloads / "d.zip", PSX, lib, overwrite=True)
+    assert forced.ok
+
+
+def test_a_missing_download_still_explains_the_mount(tmp_path):
+    result = import_rom(tmp_path / "nope.zip", PSX, tmp_path / "lib")
+    assert not result.ok
+    assert "does not exist in this container" in result.reason
+
+
+def test_a_download_with_no_rom_says_so(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"readme.nfo": b"x", "cover.png": b"y"})
+
+    result = import_rom(downloads / "g.zip", PSX, lib)
+
+    assert not result.ok
+    assert "no Sony PlayStation ROM" in result.reason
+
+
+# --- a real directory on disk, which is what a torrent client leaves -------
+
+def test_a_finished_torrent_directory_imports_as_a_set(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    folder = downloads / "Game (USA)"
+    folder.mkdir(parents=True)
+    (folder / "Game (USA).cue").write_bytes(CUE)
+    (folder / "Game (USA).bin").write_bytes(b"\x02" * 2048)
+    (folder / "readme.nfo").write_bytes(b"x")
+
+    result = import_rom(folder, PSX, lib)
+
+    assert result.ok, result.reason
+    assert sorted(p.name for p in result.destination.iterdir()) == [
+        "Game (USA).bin", "Game (USA).cue"]

--- a/tests/test_disc_platforms.py
+++ b/tests/test_disc_platforms.py
@@ -1,0 +1,154 @@
+"""Disc-based platforms are supported, and the table that says so is honest.
+
+The README used to claim disc platforms were excluded because "browser
+emulators cannot stream" them. RomM 4.9.2's own core map runs ten optical
+systems, and the stream server runs the rest, so the exclusion described
+ROMarr's importer rather than any limitation. These tests pin the platform
+table that replaces it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr import platforms
+from romarr.platforms import CARTRIDGE, COMPUTER, DISC, MB, GB, Platform, resolve
+
+
+DISC_SLUGS = (
+    "psx", "ps2", "psp", "saturn", "segacd", "dc", "ngc", "wii", "3do",
+    "philips-cd-i", "pc-fx", "turbografx-16-slash-pc-engine-cd",
+    "amiga-cd32", "neo-geo-cd", "atari-jaguar-cd",
+)
+
+
+def test_every_disc_platform_is_present():
+    """The exclusion is gone: each optical system can be named and requested."""
+    missing = [s for s in DISC_SLUGS if platforms.by_slug(s) is None]
+    assert not missing, f"disc platforms still unreachable: {missing}"
+
+
+def test_disc_platforms_declare_disc_media():
+    for slug in DISC_SLUGS:
+        assert platforms.by_slug(slug).media == DISC, slug
+
+
+def test_cartridge_platforms_kept_their_medium():
+    """Adding discs must not reclassify what already worked."""
+    for slug in ("nes", "snes", "gba", "n64", "genesis-slash-megadrive"):
+        assert platforms.by_slug(slug).media == CARTRIDGE, slug
+
+
+def test_cartridge_ceilings_are_unchanged():
+    """The per-platform ceilings were tuned against real result sets.
+
+    A disc release passing them is the bug this whole change exists to fix;
+    a cartridge ceiling drifting upward while nobody looked is how the
+    452MB PC build of Final Fantasy III got picked for a SNES request.
+    """
+    assert platforms.by_slug("nes").max_size == 8 * MB
+    assert platforms.by_slug("snes").max_size == 24 * MB
+    assert platforms.by_slug("gba").max_size == 128 * MB
+    assert platforms.by_slug("n64").max_size == 256 * MB
+
+
+@pytest.mark.parametrize("slug,floor,ceiling", [
+    # A single CD is 700MB; the ceiling has to clear an uncompressed
+    # bin/cue rip with audio tracks without admitting a PC repack.
+    ("psx", 1 * GB, 4 * GB),
+    ("saturn", 1 * GB, 4 * GB),
+    ("segacd", 1 * GB, 4 * GB),
+    ("3do", 1 * GB, 4 * GB),
+    # DVD-based. PS2 dual layer is 8.5GB.
+    ("ps2", 8 * GB, 16 * GB),
+    ("wii", 8 * GB, 16 * GB),
+    # miniDVD is 1.5GB; UMD is 1.8GB.
+    ("ngc", 2 * GB, 8 * GB),
+    ("psp", 2 * GB, 8 * GB),
+])
+def test_disc_ceilings_clear_one_disc_without_admitting_a_repack(slug, floor, ceiling):
+    platform = platforms.by_slug(slug)
+    assert floor <= platform.max_size <= ceiling, (
+        f"{slug} ceiling {platform.max_size // (1024 ** 3)}GB is outside the "
+        f"plausible range for one {platform.name} disc")
+
+
+def test_disc_platforms_prefer_a_single_file_image_first():
+    """Extension order is preference order, and a whole-disc image wins.
+
+    A `.chd` or `.rvz` is one file that cannot be separated from its
+    tracks. A `.cue` can, and routinely is -- which is the failure this
+    ordering exists to make unlikely in the first place.
+    """
+    whole_disc = {".chd", ".rvz", ".iso", ".cso", ".pbp", ".wbfs", ".gdi"}
+    for slug in DISC_SLUGS:
+        platform = platforms.by_slug(slug)
+        assert platform.extensions[0] in whole_disc, (
+            f"{slug} prefers {platform.extensions[0]!r} over a whole-disc image")
+
+
+def test_a_cue_never_appears_without_its_bin():
+    """Declaring .cue but not .bin would import a sheet pointing at nothing."""
+    for slug in DISC_SLUGS:
+        exts = platforms.by_slug(slug).extensions
+        if ".cue" in exts:
+            assert ".bin" in exts, f"{slug} declares .cue with no .bin"
+
+
+def test_playstation_resolves_from_the_names_people_use():
+    for text in ("psx", "ps1", "playstation", "PlayStation", "sony playstation"):
+        assert resolve(text) is not None and resolve(text).slug == "psx", text
+
+
+def test_playstation_2_is_not_resolved_as_playstation_1():
+    """The qualifier trap that already caught SNES/NES, one console family over.
+
+    "playstation 2" contains "playstation". Position-ranked matching has to
+    keep picking the specific one, or every PS2 request silently becomes a
+    PS1 request.
+    """
+    for text in ("ps2", "playstation 2", "PlayStation 2", "sony playstation 2"):
+        assert resolve(text).slug == "ps2", text
+
+
+def test_gamecube_and_wii_do_not_collide():
+    assert resolve("gamecube").slug == "ngc"
+    assert resolve("nintendo gamecube").slug == "ngc"
+    assert resolve("wii").slug == "wii"
+
+
+def test_dreamcast_resolves():
+    for text in ("dreamcast", "sega dreamcast", "dc"):
+        assert resolve(text).slug == "dc", text
+
+
+def test_every_slug_is_unique():
+    slugs = [p.slug for p in platforms.PLATFORMS]
+    assert len(slugs) == len(set(slugs))
+
+
+def test_every_alias_resolves_to_the_platform_that_declares_it():
+    """An alias claimed by two platforms is a silent misfiling waiting to happen."""
+    for platform in platforms.PLATFORMS:
+        for alias in platform.aliases:
+            got = resolve(alias)
+            assert got is not None, f"{platform.slug} alias {alias!r} resolves to nothing"
+            assert got.slug == platform.slug, (
+                f"{platform.slug} alias {alias!r} resolves to {got.slug}")
+
+
+def test_media_is_one_of_the_three_known_values():
+    for platform in platforms.PLATFORMS:
+        assert platform.media in (CARTRIDGE, DISC, COMPUTER), platform.slug
+
+
+def test_all_extensions_still_answers_for_every_platform():
+    every = platforms.all_extensions()
+    assert ".smc" in every and ".chd" in every and ".rvz" in every
+
+
+def test_disc_platforms_are_reported_as_such():
+    """A caller can ask which platforms need multi-file handling."""
+    disc = {p.slug for p in platforms.PLATFORMS if p.media == DISC}
+    assert set(DISC_SLUGS) <= disc
+    assert "snes" not in disc

--- a/tests/test_disc_platforms.py
+++ b/tests/test_disc_platforms.py
@@ -1,10 +1,11 @@
 """Disc-based platforms are supported, and the table that says so is honest.
 
 The README used to claim disc platforms were excluded because "browser
-emulators cannot stream" them. RomM 4.9.2's own core map runs ten optical
-systems, and the stream server runs the rest, so the exclusion described
-ROMarr's importer rather than any limitation. These tests pin the platform
-table that replaces it.
+emulators cannot stream" them. RomM 4.9.2's own core map runs nine optical
+systems -- psx, psp, saturn, segacd, 3do, philips-cd-i, pc-fx, turbografx-cd
+and amiga-cd32 -- and the stream server runs the rest, so the exclusion
+described ROMarr's importer rather than any limitation. These tests pin the
+platform table that replaces it.
 """
 
 from __future__ import annotations
@@ -152,3 +153,39 @@ def test_disc_platforms_are_reported_as_such():
     disc = {p.slug for p in platforms.PLATFORMS if p.media == DISC}
     assert set(DISC_SLUGS) <= disc
     assert "snes" not in disc
+
+
+# --- the documentation has to agree with the code --------------------------
+
+def _readme() -> str:
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[1] / "README.md").read_text(
+        encoding="utf-8")
+
+
+def test_the_readme_no_longer_excludes_disc_platforms():
+    """The claim that started this, pinned so it cannot come back.
+
+    "Disc-based platforms are excluded -- multi-gigabyte images that browser
+    emulators cannot stream." Both halves were false: RomM 4.9.2's own core
+    map runs nine optical systems in a browser, and the stream server runs the
+    rest server-side.
+    """
+    readme = _readme().lower()
+    assert "disc-based platforms are excluded" not in readme
+    assert "cannot stream" not in readme
+
+
+def test_the_readme_lists_the_disc_platforms_the_code_supports():
+    """A README that names a platform the code cannot request, or omits one it
+    can, is the same defect facing either way."""
+    readme = _readme()
+    for name in ("PlayStation 2", "Dreamcast", "GameCube", "Saturn", "PSP",
+                 "Neo Geo CD", "Amiga CD32"):
+        assert name in readme, name
+
+
+def test_the_readme_documents_every_play_route():
+    readme = _readme()
+    for route in ("EmulatorJS", "Archive.org", "Download", "STREAM_SERVER_URL"):
+        assert route in readme, route

--- a/tests/test_disc_scoring.py
+++ b/tests/test_disc_scoring.py
@@ -1,0 +1,163 @@
+"""Scoring a disc release, where several cartridge-era rules invert.
+
+The scorer was tuned against cartridge result sets and every rule in it was
+right for those. Three of them are wrong for discs, and one of the three
+would have rejected the entire correctly-dumped half of every disc search.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr.platforms import GB, MB, by_slug
+from romarr.selection import Release, best_release, explain, judge, score
+
+PSX = by_slug("psx")
+PS2 = by_slug("ps2")
+WII = by_slug("wii")
+SNES = by_slug("snes")
+CONSOLE = (1000,)
+
+
+def rel(title, size, seeders=30, categories=CONSOLE, protocol="torrent"):
+    return Release(title=title, size=size, seeders=seeders,
+                   categories=categories, download_url="magnet:?x",
+                   protocol=protocol)
+
+
+# --- the one that would have broken every disc search ----------------------
+
+def test_a_redump_dump_is_a_good_dump_not_a_compilation():
+    """Redump is the disc-preservation project, the way No-Intro is for
+    cartridges. Its name on a disc release means the dump is right.
+
+    It was in COMPILATION_MARKERS, which rejects outright -- so the single
+    most reliable quality signal a disc release carries would have thrown it
+    out, and the releases left standing would have been the unlabelled ones.
+    """
+    verdict = judge(rel("Silent Hill (USA) [Redump]", 500 * MB), "silent hill", PSX)
+    assert verdict.accepted, verdict.why()
+
+
+def test_redump_is_worth_points_on_a_disc():
+    labelled = rel("Silent Hill (USA) [Redump]", 500 * MB)
+    bare = rel("Silent Hill (USA)", 500 * MB)
+    assert score(labelled, "silent hill", PSX) > score(bare, "silent hill", PSX)
+
+
+def test_a_redump_collection_is_still_rejected():
+    """The group's name is not the licence -- a set is still a set."""
+    verdict = judge(rel("Redump - Sony PlayStation USA Collection", 400 * GB),
+                    "silent hill", PSX)
+    assert not verdict.accepted
+
+
+def test_redump_is_still_a_compilation_marker_for_a_cartridge():
+    """Nothing about the cartridge behaviour changes. A Redump-labelled SNES
+    release is a set: Redump does not dump cartridges."""
+    verdict = judge(rel("Chrono Trigger Redump", 3 * MB), "chrono trigger", SNES)
+    assert not verdict.accepted
+
+
+# --- multi-disc ------------------------------------------------------------
+
+def test_disc_one_of_a_multi_disc_game_is_not_a_compilation():
+    """How the live library stores every multi-disc PlayStation game:
+    `(Disc 1).7z`, `(Disc 2).7z`. Rejecting those rejects the game."""
+    for n in (1, 2, 3):
+        verdict = judge(
+            rel(f"Final Fantasy VII (USA) (Disc {n})", 600 * MB),
+            "final fantasy vii", PSX)
+        assert verdict.accepted, (n, verdict.why())
+
+
+# --- size ------------------------------------------------------------------
+
+def test_a_real_ps2_image_is_accepted():
+    verdict = judge(rel("Shadow of the Colossus (USA)", 4 * GB),
+                    "shadow of the colossus", PS2)
+    assert verdict.accepted, verdict.why()
+
+
+def test_a_pc_repack_is_still_too_big_for_a_ps2_request():
+    verdict = judge(rel("Shadow of the Colossus", 60 * GB),
+                    "shadow of the colossus", PS2)
+    assert not verdict.accepted
+    assert any("too big" in line for line in verdict.why())
+
+
+def test_the_size_rejection_says_disc_image_not_cartridge():
+    """An operator reading "too big for a Sony PlayStation cartridge" learns
+    that the tool does not know what a PlayStation is."""
+    lines = explain(rel("Some Game", 40 * GB), "some game", PSX)
+    joined = " ".join(lines).lower()
+    assert "disc" in joined
+    assert "cartridge" not in joined
+
+
+def test_a_cartridge_still_says_cartridge():
+    lines = explain(rel("Some Game", 900 * MB), "some game", SNES)
+    assert any("cartridge" in line.lower() for line in lines)
+
+
+def test_something_far_too_small_to_be_a_disc_is_rejected():
+    """A few hundred kilobytes offered for a PlayStation request is a patch,
+    a cheat file or a lone .cue -- never the game."""
+    verdict = judge(rel("Silent Hill (USA)", 300 * 1024), "silent hill", PSX)
+    assert not verdict.accepted
+
+
+def test_a_small_cartridge_is_not_caught_by_the_disc_floor():
+    verdict = judge(rel("Super Metroid (USA) [!]", 3 * MB), "super metroid", SNES)
+    assert verdict.accepted, verdict.why()
+
+
+# --- foreign platform markers ---------------------------------------------
+
+def test_a_wii_release_may_say_wad_without_being_refiled():
+    """"wad" catches a Virtual Console repackage offered for a *cartridge*
+    platform. On the Wii it is the catalogue."""
+    verdict = judge(rel("Mega Man 9 (USA) (WiiWare) (WAD)", 40 * MB),
+                    "mega man 9", WII)
+    assert verdict.accepted, verdict.why()
+
+
+def test_a_genesis_request_still_refuses_a_virtual_console_wad():
+    genesis = by_slug("genesis-slash-megadrive")
+    verdict = judge(rel("Phantasy.Star.IV.USA.SMD.Virtual.Console", 14 * MB),
+                    "phantasy star iv", genesis)
+    assert not verdict.accepted
+
+
+def test_a_playstation_request_still_refuses_a_ps2_release():
+    verdict = judge(rel("Final Fantasy X (USA) PS2", 4 * GB),
+                    "final fantasy x", PSX)
+    assert not verdict.accepted
+
+
+def test_a_ps2_request_is_not_refused_for_saying_playstation():
+    verdict = judge(rel("Final Fantasy X (USA) PlayStation 2", 4 * GB),
+                    "final fantasy x", PS2)
+    assert verdict.accepted, verdict.why()
+
+
+# --- ranking ---------------------------------------------------------------
+
+def test_the_smaller_of_two_equal_discs_is_not_automatically_preferred():
+    """For cartridges, bigger means romset. For a disc it can simply mean an
+    uncompressed rip of the same game, and a 100MB "PlayStation game" beside
+    a 600MB one is far more likely to be the broken one.
+    """
+    small = rel("Silent Hill (USA)", 60 * MB, seeders=5)
+    full = rel("Silent Hill (USA) [Redump]", 550 * MB, seeders=5)
+    assert best_release([small, full], "silent hill", PSX) is full
+
+
+def test_a_cartridge_still_prefers_the_smaller_file():
+    dump = rel("Super Metroid (USA) [!]", 3 * MB, seeders=5)
+    bigger = rel("Super Metroid (USA)", 20 * MB, seeders=5)
+    assert best_release([bigger, dump], "super metroid", SNES) is dump
+
+
+def test_nothing_qualifying_is_still_none():
+    assert best_release([], "anything", PSX) is None

--- a/tests/test_interactive_search.py
+++ b/tests/test_interactive_search.py
@@ -108,8 +108,11 @@ def test_a_download_url_never_reaches_the_browser(tmp_path):
 def test_an_unknown_platform_is_refused_rather_than_scored_blind(tmp_path):
     s = svc(tmp_path)
     s.prowlarr = FakeProwlarr([])
-    out = s.candidates("Final Fantasy VII", "psx")
-    assert out["unknown_platform"] == "psx"
+    # `psx` was the example here until it became a supported platform. The
+    # rule under test is unchanged: a name nothing recognises must be refused,
+    # not scored as though no platform had been asked for.
+    out = s.candidates("Astro Bot", "playstation 5")
+    assert out["unknown_platform"] == "playstation 5"
     assert out["items"] == []
 
 

--- a/tests/test_play_routes_api.py
+++ b/tests/test_play_routes_api.py
@@ -1,0 +1,86 @@
+"""The play-route answer, as the API and the status page serve it."""
+
+from __future__ import annotations
+
+from romarr.app import ROMarr
+
+
+def svc(tmp_path, **env):
+    return ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"), **env})
+
+
+def test_the_platform_directory_says_how_each_one_plays(tmp_path):
+    directory = svc(tmp_path).platform_directory()
+    by_slug = {row["slug"]: row for row in directory}
+
+    assert by_slug["psx"]["media"] == "disc"
+    assert "local" in by_slug["psx"]["play_routes"]
+    assert by_slug["psx"]["plays"] is True
+
+    assert by_slug["snes"]["media"] == "cartridge"
+    assert "local" in by_slug["snes"]["play_routes"]
+
+
+def test_every_platform_in_the_directory_can_be_downloaded(tmp_path):
+    for row in svc(tmp_path).platform_directory():
+        assert "download" in row["play_routes"], row["slug"]
+
+
+def test_the_directory_carries_the_extensions_the_importer_uses(tmp_path):
+    by_slug = {r["slug"]: r for r in svc(tmp_path).platform_directory()}
+    assert by_slug["psx"]["extensions"][0] == ".chd"
+    assert ".bin" in by_slug["psx"]["extensions"]
+
+
+def test_status_counts_the_routes(tmp_path):
+    counts = svc(tmp_path).status()["play_routes"]
+    assert counts["total"] > 30
+    assert counts["local"] > 20
+    # Without a stream server, the heavy machines are download-only. Saying so
+    # is the point: it is what makes configuring one an obvious win.
+    assert counts["download_only"] >= 5
+
+
+def test_configuring_a_stream_server_is_visible_in_status(tmp_path):
+    plain = svc(tmp_path)
+    assert plain.stream is None
+    assert plain.status()["stream_url"] == ""
+
+    wired = svc(tmp_path / "b", STREAM_SERVER_URL="http://stream.test:8080")
+    assert wired.stream is not None
+    assert wired.status()["stream_url"] == "http://stream.test:8080"
+
+
+def test_an_unreachable_stream_server_does_not_break_the_status_page(tmp_path):
+    """A LAN service being down is normal and must cost a route, not a page."""
+    wired = svc(tmp_path, STREAM_SERVER_URL="http://stream.invalid:9")
+    wired.stream.timeout = 0.05
+    status = wired.status()
+    assert status["play_routes"]["total"] > 30
+    assert status["play_routes"]["download_only"] >= 5
+
+
+def test_a_down_stream_server_is_asked_once_not_once_per_platform(tmp_path):
+    """The status page walks every platform. Only *successful* answers are
+    cached -- a failure must never be remembered as "cannot play this" -- so
+    without a breaker one down server costs one timeout per platform.
+
+    Measured at 69 seconds for a single status page before the breaker
+    existed, on an install where the stream server is entirely optional.
+    """
+    wired = svc(tmp_path, STREAM_SERVER_URL="http://stream.invalid:9")
+    attempts = []
+    real = wired.stream.tier
+
+    def counting(slug):
+        attempts.append(slug)
+        return real(slug)
+
+    wired.stream.timeout = 0.05
+    wired.stream.tier = counting
+    wired.status()
+
+    # Every platform is still asked; the client answers all but the first
+    # from its own breaker without touching the network.
+    assert len(attempts) > 30
+    assert wired.stream._down_until > 0

--- a/tests/test_playability.py
+++ b/tests/test_playability.py
@@ -1,0 +1,246 @@
+"""How a platform will play, said before the grab rather than after.
+
+A ROM filed under a platform with no route is imported but dead: it appears
+in the library, it has a cover, and clicking it does nothing. This module
+does not refuse anything -- cataloguing is a legitimate use of a library --
+it makes sure the operator knows which of the four routes applies first.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr import playability
+from romarr.playability import (
+    ARCHIVE, DOWNLOAD, LOCAL, STREAM, Playability, routes_for)
+from romarr.platforms import PLATFORMS, by_slug
+
+
+class FakeStream:
+    """Stands in for a romm-stream server's /api/play/route."""
+
+    def __init__(self, tiers, unreachable=""):
+        self.tiers = tiers
+        self.unreachable = unreachable
+        self.asked = []
+
+    def tier(self, slug):
+        self.asked.append(slug)
+        if self.unreachable:
+            return None
+        return self.tiers.get(slug)
+
+    @property
+    def reachable(self):
+        return not self.unreachable
+
+    @property
+    def label(self):
+        return "http://stream.test"
+
+
+# --- nothing is excluded ---------------------------------------------------
+
+def test_every_platform_has_at_least_one_route():
+    """The whole claim, as a test. No platform in the table is a dead end."""
+    for platform in PLATFORMS:
+        got = routes_for(platform)
+        assert got.routes, platform.slug
+        assert DOWNLOAD in got.kinds, platform.slug
+
+
+def test_download_is_always_available():
+    """A ROM in a library is a ROM you can download. That is an answer, not a
+    failure, and it is the floor every platform stands on."""
+    for slug in ("snes", "psx", "ps2", "neo-geo-cd"):
+        assert DOWNLOAD in routes_for(by_slug(slug)).kinds
+
+
+# --- EmulatorJS, the local tier -------------------------------------------
+
+@pytest.mark.parametrize("slug", [
+    "psx", "psp", "saturn", "segacd", "3do", "philips-cd-i", "pc-fx",
+    "turbografx-16-slash-pc-engine-cd", "amiga-cd32",
+])
+def test_the_optical_systems_emulatorjs_runs_are_reported_as_local(slug):
+    """Nine optical systems in RomM 4.9.2's base core map.
+
+    This is the fact the README's exclusion denied outright, so it is pinned
+    per platform rather than as a count.
+    """
+    got = routes_for(by_slug(slug))
+    assert LOCAL in got.kinds, got.summary()
+
+
+def test_a_local_route_names_the_core_that_runs_it():
+    got = routes_for(by_slug("psx"))
+    local = next(r for r in got.routes if r.kind == LOCAL)
+    assert "pcsx_rearmed" in local.detail
+
+
+@pytest.mark.parametrize("slug", ["ps2", "ngc", "wii", "dc", "3ds"])
+def test_the_systems_emulatorjs_cannot_run_are_not_claimed_as_local(slug):
+    """Over-claiming here is the failure mode that matters.
+
+    A platform wrongly reported playable sends the operator to a game that
+    imports, displays and does nothing. Under-claiming costs them a warning
+    they did not need.
+    """
+    assert LOCAL not in routes_for(by_slug(slug)).kinds
+
+
+def test_cartridge_platforms_kept_their_local_route():
+    for slug in ("nes", "snes", "gba", "n64", "genesis-slash-megadrive"):
+        assert LOCAL in routes_for(by_slug(slug)).kinds, slug
+
+
+# --- the headless RetroArch stream tier ------------------------------------
+
+def test_a_stream_server_supplies_routes_emulatorjs_cannot():
+    stream = FakeStream({"ps2": "stream", "wii": "stream", "dc": "stream"})
+    for slug in ("ps2", "wii", "dc"):
+        got = routes_for(by_slug(slug), stream=stream)
+        assert STREAM in got.kinds, got.summary()
+
+
+def test_the_stream_server_is_asked_by_slug():
+    stream = FakeStream({"ps2": "stream"})
+    routes_for(by_slug("ps2"), stream=stream)
+    assert stream.asked == ["ps2"]
+
+
+def test_a_stream_server_that_answers_local_does_not_invent_a_stream_route():
+    """The server distinguishes the two tiers and so must this. Reporting
+    'streamed server-side' for something the browser runs is a lie about
+    where the CPU time goes."""
+    stream = FakeStream({"psx": "local"})
+    got = routes_for(by_slug("psx"), stream=stream)
+    assert STREAM not in got.kinds
+    assert LOCAL in got.kinds
+
+
+def test_no_stream_server_is_not_an_error():
+    """Most installs have no stream server. That must degrade to the other
+    routes, never to a failure or an empty answer."""
+    got = routes_for(by_slug("psx"), stream=None)
+    assert LOCAL in got.kinds and DOWNLOAD in got.kinds
+    assert STREAM not in got.kinds
+
+
+def test_an_unreachable_stream_server_degrades_and_says_so():
+    stream = FakeStream({"ps2": "stream"}, unreachable="connection refused")
+    got = routes_for(by_slug("ps2"), stream=stream)
+    assert STREAM not in got.kinds
+    assert DOWNLOAD in got.kinds
+    assert "unreachable" in got.summary().lower()
+
+
+def test_ps2_has_no_route_but_download_without_a_stream_server():
+    """Honest, and the reason the stream server is worth configuring."""
+    got = routes_for(by_slug("ps2"), stream=None)
+    assert got.kinds == (DOWNLOAD,)
+    assert not got.plays_without_downloading
+
+
+# --- Archive.org's in-page emulator ---------------------------------------
+
+def test_archive_org_is_offered_where_it_really_emulates():
+    for slug in ("nes", "snes", "gba", "atari2600", "genesis-slash-megadrive"):
+        assert ARCHIVE in routes_for(by_slug(slug)).kinds, slug
+
+
+@pytest.mark.parametrize("slug", ["psx", "ps2", "saturn", "3do", "dc", "psp"])
+def test_archive_org_is_not_claimed_for_disc_systems(slug):
+    """Measured against Archive.org's own `emulator` metadata field, which
+    272,424 of their items carry. The disc drivers return nothing:
+    psj/psu/pse 0, saturn 0, 3do 0, dc 2, segacd 1.
+
+    Archive.org is a *source* for disc images, not a player of them, and
+    claiming otherwise would send an operator to a details page that offers
+    a download and no emulator.
+    """
+    assert ARCHIVE not in routes_for(by_slug(slug)).kinds
+
+
+def test_the_archive_table_records_when_it_was_measured():
+    """A vendored copy of somebody else's data goes stale. One that says
+    what it is stale relative to can be checked; one that does not, cannot."""
+    assert playability.ARCHIVE_MEASURED_ON
+
+
+# --- shape -----------------------------------------------------------------
+
+def test_routes_are_ordered_best_first():
+    got = routes_for(by_slug("psx"))
+    assert got.kinds[0] == LOCAL
+    assert got.kinds[-1] == DOWNLOAD
+
+
+def test_stream_outranks_download_but_not_local():
+    stream = FakeStream({"psx": "stream"})
+    got = routes_for(by_slug("psx"), stream=stream)
+    assert list(got.kinds).index(LOCAL) < list(got.kinds).index(DOWNLOAD)
+
+
+def test_summary_is_one_readable_line():
+    summary = routes_for(by_slug("psx")).summary()
+    assert "\n" not in summary
+    assert "PlayStation" in summary
+
+
+def test_plays_without_downloading_is_the_honest_question():
+    assert routes_for(by_slug("psx")).plays_without_downloading
+    assert not routes_for(by_slug("neo-geo-cd")).plays_without_downloading
+
+
+def test_a_platform_with_no_player_says_which_would_fix_it():
+    """"download only" on its own leaves the operator with nowhere to go."""
+    got = routes_for(by_slug("ps2"), stream=None)
+    assert "stream server" in got.summary().lower()
+
+
+def test_the_stream_servers_own_reason_wins_when_it_gave_one():
+    """Live example from the stream server on CT104: PCSX2 is installed and
+    PS2 is still unplayable, because it has no BIOS.
+
+    "configure a stream server to play it here" is exactly wrong for that
+    operator -- they have one. The actionable answer is the firmware, and only
+    the server knows which of its three reasons applies.
+    """
+    class Firmwareless(FakeStream):
+        def why(self, slug):
+            return "the stream server needs firmware for this platform: bios"
+
+    got = routes_for(by_slug("ps2"), stream=Firmwareless({}))
+    assert "firmware" in got.summary()
+    assert "configure a stream server" not in got.summary()
+
+
+def test_the_generic_reason_is_used_when_the_server_says_nothing():
+    got = routes_for(by_slug("ps2"), stream=FakeStream({}))
+    assert "configure a stream server" in got.summary()
+
+
+def test_a_stream_server_whose_why_raises_does_not_break_the_answer():
+    class Broken(FakeStream):
+        def why(self, slug):
+            raise RuntimeError("nope")
+
+    got = routes_for(by_slug("ps2"), stream=Broken({}))
+    assert DOWNLOAD in got.kinds
+
+
+def test_result_is_frozen():
+    got = routes_for(by_slug("snes"))
+    assert isinstance(got, Playability)
+    with pytest.raises(Exception):
+        got.routes = ()
+
+
+def test_a_slug_string_works_as_well_as_a_platform():
+    assert routes_for("psx").kinds == routes_for(by_slug("psx")).kinds
+
+
+def test_an_unknown_platform_is_not_guessed_at():
+    got = routes_for("playstation 5")
+    assert got.kinds == (DOWNLOAD,)

--- a/tests/test_playability.py
+++ b/tests/test_playability.py
@@ -244,3 +244,35 @@ def test_a_slug_string_works_as_well_as_a_platform():
 def test_an_unknown_platform_is_not_guessed_at():
     got = routes_for("playstation 5")
     assert got.kinds == (DOWNLOAD,)
+
+
+# --- the cache must not outlive the fact it caches -------------------------
+
+def test_a_successful_answer_expires_so_a_new_core_is_noticed():
+    """Found by installing one.
+
+    The cache was for the process lifetime, on the reasoning that a routing
+    table built from what is on disk does not change while the server is up.
+    Installing `neocd_libretro.so` and restarting the stream server falsified
+    that: Neo Geo CD went from unplayable to streaming, and ROMarr kept
+    reporting "no emulator exists" until it too was restarted -- a confusing
+    way to be told that your work succeeded.
+    """
+    from romarr.playability import StreamServer
+
+    server = StreamServer("http://stream.test")
+    server._cache["neo-geo-cd"] = ("stream", 0.0)      # already expired
+    # An expired entry must not be returned; with no reachable server the call
+    # falls through to the network and fails closed rather than serving stale.
+    server.timeout = 0.01
+    assert server.tier("neo-geo-cd") is None
+
+
+def test_a_live_answer_inside_the_ttl_is_reused():
+    import time as _time
+
+    from romarr.playability import StreamServer
+
+    server = StreamServer("http://stream.test")
+    server._cache["psx"] = ("local", _time.monotonic() + 300)
+    assert server.tier("psx") == "local"

--- a/tests/test_rom_set.py
+++ b/tests/test_rom_set.py
@@ -1,0 +1,225 @@
+"""A disc game is a set of files, and importing the sheet alone is silent death.
+
+`pick_rom_file` answered with one filename. For a cartridge that is the whole
+game. For a disc it is often a `.cue` -- a few hundred bytes of text naming
+tracks that were left behind -- and the resulting library entry has a cover,
+a title, a size, and boots nothing. Nothing downstream can detect that.
+
+These tests pin the set, not the file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr.platforms import by_slug
+from romarr.selection import RomSet, pick_rom_file, pick_rom_set
+
+PSX = by_slug("psx")
+DC = by_slug("dc")
+SNES = by_slug("snes")
+PS2 = by_slug("ps2")
+WII = by_slug("wii")
+
+
+def reader(contents: dict[str, str]):
+    """A `read` callable over an in-memory archive listing."""
+    def read(name: str) -> bytes | None:
+        text = contents.get(name)
+        return text.encode() if text is not None else None
+    return read
+
+
+# --- cartridges are unchanged ----------------------------------------------
+
+def test_a_cartridge_is_a_set_of_one():
+    got = pick_rom_set(["Super Metroid (USA).smc", "readme.nfo"], SNES)
+    assert got.primary == "Super Metroid (USA).smc"
+    assert got.members == ("Super Metroid (USA).smc",)
+    assert not got.is_multi_file
+
+
+def test_pick_rom_file_still_answers_for_callers_that_want_one_name():
+    """The old entry point keeps working, on top of the new one.
+
+    Two implementations of "which file is the ROM" would drift, and the one
+    that drifted would be the one nobody was testing.
+    """
+    assert pick_rom_file(["Zelda.smc", "box.jpg"], SNES) == "Zelda.smc"
+    assert pick_rom_file(["nothing.txt"], SNES) is None
+
+
+def test_nothing_playable_is_still_none():
+    assert pick_rom_set(["readme.nfo", "cover.png"], PSX) is None
+
+
+# --- the failure this exists to prevent ------------------------------------
+
+def test_a_cue_brings_its_bin():
+    files = ["Final Fantasy VII (USA) (Disc 1).cue",
+             "Final Fantasy VII (USA) (Disc 1).bin",
+             "readme.nfo"]
+    sheet = 'FILE "Final Fantasy VII (USA) (Disc 1).bin" BINARY\n' \
+            '  TRACK 01 MODE2/2352\n    INDEX 01 00:00:00\n'
+    got = pick_rom_set(files, PSX,
+                       read=reader({"Final Fantasy VII (USA) (Disc 1).cue": sheet}))
+    assert got.primary.endswith(".cue")
+    assert "Final Fantasy VII (USA) (Disc 1).bin" in got.members
+    assert got.is_multi_file
+    assert "readme.nfo" not in got.members
+
+
+def test_a_cue_with_many_audio_tracks_brings_all_of_them():
+    files = ["game.cue"] + [f"game (Track {i:02d}).bin" for i in range(1, 8)]
+    sheet = "".join(
+        f'FILE "game (Track {i:02d}).bin" BINARY\n  TRACK {i:02d} AUDIO\n'
+        for i in range(1, 8))
+    got = pick_rom_set(files, PSX, read=reader({"game.cue": sheet}))
+    assert len(got.members) == 8
+    for i in range(1, 8):
+        assert f"game (Track {i:02d}).bin" in got.members
+
+
+def test_a_gdi_brings_its_tracks():
+    """The live library's Dreamcast layout, verbatim.
+
+    `dc/102 Dalmatians - Puppies to the Rescue (NA, Rev 1.001)/` holds a
+    149-byte .gdi and five track files whose names share nothing with it --
+    which is exactly why sidecars are read out of the sheet rather than
+    guessed from the stem.
+    """
+    files = ["102 Dalmatians v1.001 (2000)(EIDOS)(NTSC)(US)[!].gdi",
+             "track01.bin", "track02.raw", "track03.bin", "track04.raw",
+             "track05.bin"]
+    sheet = ("5\n"
+             "1 0 4 2352 track01.bin 0\n"
+             "2 600 0 2352 track02.raw 0\n"
+             "3 45000 4 2352 track03.bin 0\n"
+             "4 250000 0 2352 track04.raw 0\n"
+             "5 300000 4 2352 track05.bin 0\n")
+    got = pick_rom_set(files, DC, read=reader({files[0]: sheet}))
+    assert got.primary.endswith(".gdi")
+    assert set(got.members) == set(files)
+
+
+def test_an_unquoted_cue_filename_is_read():
+    """Not every cue quotes its FILE argument, and an unread sheet is a
+    silently incomplete import rather than an error."""
+    files = ["game.cue", "game.bin"]
+    got = pick_rom_set(files, PSX,
+                       read=reader({"game.cue": "FILE game.bin BINARY\n"}))
+    assert "game.bin" in got.members
+
+
+# --- whole-disc images need no sidecars ------------------------------------
+
+def test_a_chd_is_a_set_of_one():
+    got = pick_rom_set(["Silent Hill (USA).chd", "cover.png"], PSX)
+    assert got.members == ("Silent Hill (USA).chd",)
+    assert not got.is_multi_file
+
+
+def test_a_chd_is_preferred_over_a_cue_bin_pair():
+    """One file that cannot be separated from its tracks beats two that can."""
+    files = ["game.chd", "game.cue", "game.bin"]
+    got = pick_rom_set(files, PSX, read=reader({"game.cue": 'FILE "game.bin" BINARY\n'}))
+    assert got.primary == "game.chd"
+    assert not got.is_multi_file
+
+
+def test_an_rvz_is_preferred_for_wii():
+    got = pick_rom_set(["Metroid Prime 3 (USA).rvz", "Metroid Prime 3 (USA).iso"], WII)
+    assert got.primary.endswith(".rvz")
+
+
+# --- multi-disc ------------------------------------------------------------
+
+def test_an_m3u_binds_every_disc_it_lists():
+    """A playlist is what makes a multi-disc game work in RetroArch and
+    EmulatorJS alike. Importing one disc of three is not importing the game."""
+    files = ["Final Fantasy VII.m3u",
+             "Final Fantasy VII (Disc 1).chd",
+             "Final Fantasy VII (Disc 2).chd",
+             "Final Fantasy VII (Disc 3).chd"]
+    playlist = "\n".join(files[1:]) + "\n"
+    got = pick_rom_set(files, PSX, read=reader({"Final Fantasy VII.m3u": playlist}))
+    assert got.primary.endswith(".m3u")
+    assert set(got.members) == set(files)
+    assert got.is_multi_file
+
+
+def test_two_discs_in_one_directory_do_not_bleed_into_each_other():
+    """Each cue takes its own tracks. A glob for "every .bin nearby" would
+    hand disc 1 both discs' data and produce a set that boots the wrong one."""
+    files = ["Disc 1/game.cue", "Disc 1/game.bin",
+             "Disc 2/game.cue", "Disc 2/game.bin"]
+    sheets = {"Disc 1/game.cue": 'FILE "game.bin" BINARY\n',
+              "Disc 2/game.cue": 'FILE "game.bin" BINARY\n'}
+    got = pick_rom_set(files, PSX, read=reader(sheets))
+    assert len(got.members) == 2
+    parents = {m.rsplit("/", 1)[0] for m in got.members}
+    assert len(parents) == 1, f"set spans two discs: {got.members}"
+
+
+# --- the fallback, when the sheet cannot be read ---------------------------
+
+def test_an_unreadable_sheet_falls_back_to_every_track_beside_it():
+    """Over-inclusive on purpose.
+
+    Taking a file too many costs disk. Taking one too few costs a game that
+    imports, displays, and does not boot -- and nothing downstream can tell.
+    """
+    files = ["game.gdi", "track01.bin", "track02.raw", "track03.bin"]
+    got = pick_rom_set(files, DC, read=None)
+    assert set(got.members) == set(files)
+
+
+def test_the_fallback_prefers_a_shared_stem_when_there_is_one():
+    files = ["Game A.cue", "Game A (Track 01).bin", "Game A (Track 02).bin",
+             "Game B.cue", "Game B (Track 01).bin"]
+    got = pick_rom_set(files, PSX, read=None)
+    assert all(m.startswith("Game A") for m in got.members), got.members
+
+
+def test_a_read_that_raises_is_treated_as_unreadable_not_fatal():
+    def boom(name):
+        raise OSError("archive member unreadable")
+    files = ["game.cue", "game.bin"]
+    got = pick_rom_set(files, PSX, read=boom)
+    assert "game.bin" in got.members
+
+
+# --- sanity ----------------------------------------------------------------
+
+def test_the_primary_is_always_a_member():
+    for files, platform, read in [
+        (["a.smc"], SNES, None),
+        (["a.chd"], PSX, None),
+        (["a.cue", "a.bin"], PSX, reader({"a.cue": 'FILE "a.bin" BINARY\n'})),
+    ]:
+        got = pick_rom_set(files, platform, read=read)
+        assert got.primary in got.members
+
+
+def test_members_never_include_an_extra():
+    files = ["game.cue", "game.bin", "game.nfo", "cover.jpg", "game.sfv"]
+    got = pick_rom_set(files, PSX, read=reader({"game.cue": 'FILE "game.bin" BINARY\n'}))
+    assert set(got.members) == {"game.cue", "game.bin"}
+
+
+def test_a_ps2_iso_is_a_set_of_one():
+    got = pick_rom_set(["Shadow of the Colossus (USA).iso"], PS2)
+    assert got.members == ("Shadow of the Colossus (USA).iso",)
+
+
+def test_region_preference_still_decides_between_two_dumps():
+    files = ["Game (Japan).chd", "Game (USA).chd"]
+    got = pick_rom_set(files, PSX)
+    assert got.primary == "Game (USA).chd"
+
+
+def test_rom_set_is_frozen():
+    got = pick_rom_set(["a.smc"], SNES)
+    assert isinstance(got, RomSet)
+    with pytest.raises(Exception):
+        got.primary = "b.smc"

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -18,9 +18,25 @@ def rel(title, *, size=512 * 1024, seeders=20, cats=(1030,),
 def test_resolves_common_names_and_aliases():
     assert resolve("SNES").slug == "snes"
     assert resolve("Super Nintendo").slug == "snes"
-    assert resolve("super famicom").slug == "snes"
     assert resolve("Nintendo 64").slug == "n64"
     assert resolve("mega drive").slug == "genesis-slash-megadrive"
+
+
+def test_the_japanese_machines_reach_their_own_folders():
+    """"famicom" and "super famicom" were aliases of nes and snes, which was
+    right while those were the only folders ROMarr could file into.
+
+    RomM keeps them separate and the live library fills both -- 106 famicom,
+    968 fds, 127 sfam -- so filing a Super Famicom request under `snes` puts
+    it in a folder its requester did not ask for and leaves the one they did
+    ask for empty.
+    """
+    assert resolve("super famicom").slug == "sfam"
+    assert resolve("famicom").slug == "famicom"
+    assert resolve("famicom disk system").slug == "fds"
+    # The western twins are untouched.
+    assert resolve("nes").slug == "nes"
+    assert resolve("snes").slug == "snes"
 
 
 def test_longer_alias_wins_over_shorter_substring():

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -448,12 +448,30 @@ def test_a_retranslation_is_penalised_like_a_translation():
             < score(clean, "chrono trigger", snes), word
 
 
-def test_every_platform_declares_a_ceiling_above_its_biggest_cartridge():
-    from romarr.platforms import PLATFORMS
+def test_every_platform_declares_a_ceiling_matched_to_its_medium():
+    """A ceiling has to be loose enough to admit the game and tight enough to
+    keep a PC repack out, and where that line sits depends on the medium.
+
+    This was one number for every platform, because every platform was a
+    cartridge. Splitting it by medium is what lets a 4GB PS2 image through
+    while a 452MB PC build of Final Fantasy III still cannot pass for a SNES
+    cartridge -- the failure the per-platform ceiling was introduced for.
+    """
+    from romarr.platforms import CARTRIDGE, COMPUTER, DISC, GB, PLATFORMS
+    limits = {
+        # Nothing cartridge-era needs a third of a gigabyte -- except the two
+        # late handhelds, whose cards genuinely are that big.
+        CARTRIDGE: 300 * 1024 * 1024,
+        DISC: 16 * GB,
+        COMPUTER: 4 * GB,
+    }
+    big_cards = {"nds", "3ds"}
     for p in PLATFORMS:
         assert p.max_size > 0, p.slug
-        # Nothing cartridge-era needs a third of a gigabyte.
-        assert p.max_size < 300 * 1024 * 1024, p.slug
+        if p.slug in big_cards:
+            assert p.max_size <= 8 * GB, p.slug
+            continue
+        assert p.max_size < limits[p.media], p.slug
 
 
 # --- repackaged games are not cartridge dumps -------------------------------


### PR DESCRIPTION
The README said:

> Disc-based platforms are excluded — multi-gigabyte images that browser emulators cannot stream.

Both halves were false, and this ecosystem's own code disproves them.

**Browser emulators do run disc systems.** RomM 4.9.2's `_EJS_CORES_MAP` gives EmulatorJS cores for nine optical systems on a stock install: `psx`, `psp`, `saturn`, `segacd`, `3do`, `philips-cd-i`, `pc-fx`, `turbografx-cd`, `amiga-cd32`.

**What EmulatorJS cannot run, the stream server already does** — PS2, GameCube, Wii, Dreamcast, 3DS under headless RetroArch, delivered as video. The client never sees the multi-gigabyte image.

**And the library already held them** — 2,621 psx, 2,409 ps2, 1,470 wii, 992 dc, acquired by hand because ROMarr refused to acquire them.

The exclusion never described a limitation. It described ROMarr's importer.

## What this changes

**58 platforms**, up from 16 — every machine with a real play route. Disc, cartridge and home computer. Slugs verified against both the live library's 394 platform folders and RomM's core map; extensions and ceilings read off the library rather than recalled.

**A disc is a set, not a file.** `pick_rom_set` returns everything that must travel together. A `.cue` is a few hundred bytes of text naming tracks — importing it alone gives a library entry with a title, a cover, a plausible size and no game, and nothing downstream can detect that. Sidecars are read out of the sheet, never globbed, because a download holding two discs has both sheets saying `game.bin`.

**`.7z` and `.rar` open.** The disc library is almost entirely `.7z`; a zip-only importer supported those platforms on paper only.

**Multi-file sets land as a directory**, which is what RomM's own scanner treats as one multi-part ROM (`get_roms()` lists files *and* directories under the platform folder).

**Play routes are stated up front** — `local` / `stream` / `archive` / `download` — on a new System → Platforms page and `/api/platforms`.

## Things found on the way

- `resolve("PlayStation 5")` returned the **PlayStation 1** folder. Family names prefix every generation.
- `redump` was in `COMPILATION_MARKERS`, which rejects outright. Redump is the disc-preservation project — every correctly-labelled dump would have been thrown out and the unlabelled ones left standing.
- A down stream server made the status page take **69 seconds** (one timeout per platform).
- `famicom` and `super famicom` were aliases of `nes`/`snes`, so Super Famicom requests landed in a folder nobody asked for while the right one stayed empty.
- Arcade, Neo Geo and DOS need `archive_is_the_rom` — for MAME/FBNeo/dosbox the `.zip` **is** the ROM, and unpacking it shreds a romset.
- The `.gdi` sheet parser used `\s+`, which spans newlines, silently dropping track one from every Dreamcast set.

## Proof

Run against real files from the live library, not fixtures — a real PlayStation `.7z` (cue+bin), the real Dreamcast `.gdi` layout, six real-shaped releases scored, and play routes resolved against the real stream server. The script is committed at `docs/superpowers/specs/2026-08-02-disc-proof.py`.

**351 tests green.**

## Still not playable, and why

- **Atari Jaguar CD** — no emulator plays it. `virtualjaguar` declares cartridge extensions only; MAME's own source marks `jaguarcd` `MACHINE_NOT_WORKING`.
- **Sharp X68000** — `px68k` is installed and wants Sharp's `iplrom.dat`/`cgrom.dat`. No free equivalent exists the way C-BIOS does for MSX.

Both are reported with their reason rather than hidden. 56 of 58 platforms play without downloading.

Companion fixes in [RommStreamServer](https://github.com/BlizzHacker/RommStreamServer): the route endpoint that never consulted the GPU host, Neo Geo CD support, and a `system_directory` bug that had the firmware gate and the emulator reading different directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)