### PR TITLE
Set the standard: authenticate, index anything, and prove the file is right

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,25 @@ stack by MoveWeight.
 
 Brand and naming: [BRAND.md](https://github.com/BlizzHacker/rom-hub/blob/master/BRAND.md).
 
+## Acknowledgements
+
+**[gamarr](https://github.com/JeremiahM37/gamarr)** by JeremiahM37 (MIT).
+Several features here exist because gamarr had them first and its README made
+the case for them plainly: the blocklist, release profiles, quality profiles,
+notification connections, tags, manual import, and Prometheus metrics. No code
+was taken — gamarr is Go and ROMarr is Python, and every implementation here
+was written from scratch — but the feature set was informed by theirs, and
+saying so is the least that is owed.
+
+**Radarr and Sonarr**, for the shape of the whole category: indexer and
+download-client registries rendered from field definitions, quality and
+release profiles, remote path mappings, and Manual Import.
+
+**No-Intro** and **[Redump](http://redump.org)**, whose DATs make
+verification possible at all. **[RomM](https://github.com/rommapp/romm)**,
+whose EmulatorJS core map is the basis of the playability routing.
+
+
 ## Licence
 
 MIT — see [LICENSE](LICENSE).

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,84 @@
+# Frontend plugins
+
+Plugins for [Playnite](https://playnite.link) and
+[LaunchBox](https://www.launchbox-app.com), plus the reference for ES-DE.
+
+## What is proven and what is not
+
+Be clear about this before installing anything here.
+
+**The ROMarr side is tested** — `romarr/frontends.py` and its 20 tests. Every
+export format is a pure function from library rows to text, and the tests cover
+the platform-name mapping, XML escaping, relative paths, missing files and an
+empty library.
+
+**The plugins in this directory are not.** LaunchBox plugins are compiled .NET
+assemblies and Playnite extensions run inside Playnite; neither can be built or
+executed in the environment ROMarr is developed in. The source is written
+against each project's documented API, and it has not been run.
+
+That is why the integration is built on the exports rather than on the plugins.
+A plugin breaks when the host changes its API; a `gamelist.xml` has been read
+the same way for fifteen years. **If a plugin here ever stops working, use the
+export — it is the supported path.**
+
+## The endpoint they all use
+
+```
+GET /api/v1/frontend/export?format=launchbox|gamelist|playnite
+X-Api-Key: <your key>
+```
+
+`launchbox` and `gamelist` return XML, `playnite` returns JSON. Add
+`&platform=<slug>` to export one system — which is required for `gamelist`,
+since EmulationStation keeps one file per system directory.
+
+## Playnite
+
+`playnite/` is a **script extension**: PowerShell, no compilation, and it
+installs by copying the folder.
+
+1. Copy `playnite/ROMarr` into `%APPDATA%\Playnite\Extensions\`.
+2. Restart Playnite.
+3. **Extensions → ROMarr → Configure**, and paste your ROMarr URL and API key.
+4. **Extensions → ROMarr → Sync library**.
+
+Playnite's *Library* plugin interface — the one that makes ROMarr appear as a
+library source alongside Steam and GOG — is C#-only. This uses a Generic
+extension with a menu item instead, which imports the same games without
+requiring a compiled assembly. That is a deliberate trade: something you can
+install and read the source of, over something that needs a build toolchain.
+
+## LaunchBox
+
+Two ways in, and the second is the one to reach for first.
+
+**Import the XML.** Export `format=launchbox`, then in LaunchBox use
+**Tools → Import → LaunchBox XML**. Nothing to install and nothing to break.
+
+**Or build the plugin.** `launchbox/` is a .NET class library against
+`Unbroken.LaunchBox.Plugins`. It adds a *ROMarr → Sync* menu item.
+
+```
+cd contrib/launchbox
+dotnet build -c Release
+```
+
+Copy the resulting DLL into `LaunchBox\Plugins\ROMarr\`. You will need
+`Unbroken.LaunchBox.Plugins.dll` from your own LaunchBox installation as a
+reference — it is not redistributable, which is the other reason this is not
+the recommended path.
+
+## ES-DE, Batocera, RetroPie, Recalbox
+
+No plugin needed. These read a ROM directory and a `gamelist.xml`, which is
+what ROMarr already writes:
+
+```bash
+curl -H "X-Api-Key: $KEY" \
+  "http://romarr:6868/api/v1/frontend/export?format=gamelist&platform=snes" \
+  > /roms/snes/gamelist.xml
+```
+
+ROMarr's `folder` library backend already writes the directory layout these
+expect, so for most installs the gamelist is the only extra step.

--- a/contrib/launchbox/ROMarrPlugin.cs
+++ b/contrib/launchbox/ROMarrPlugin.cs
@@ -1,0 +1,173 @@
+// ROMarr -> LaunchBox
+//
+// A system menu item that pulls the library from ROMarr and adds anything
+// LaunchBox does not already have.
+//
+// NOT BUILT OR RUN. LaunchBox plugins are compiled .NET assemblies referencing
+// Unbroken.LaunchBox.Plugins.dll, which ships with LaunchBox and is not
+// redistributable, so this cannot be compiled in ROMarr's own environment.
+// It is written against the documented API and has not been executed.
+//
+// The supported path is the XML export -- Tools -> Import -> LaunchBox XML.
+// See contrib/README.md.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml.Linq;
+using Unbroken.LaunchBox.Plugins;
+using Unbroken.LaunchBox.Plugins.Data;
+
+namespace ROMarr
+{
+    public class ROMarrSyncMenuItem : ISystemMenuItemPlugin
+    {
+        public string Caption => "Sync from ROMarr";
+        public System.Drawing.Image IconImage => null;
+        public bool ShowInLaunchBox => true;
+        public bool ShowInBigBox => false;
+        public bool AllowInBigBoxWhenLocked => false;
+
+        public void OnSelected()
+        {
+            var settings = ROMarrSettings.Load();
+            if (settings == null)
+            {
+                MessageBox.Show(
+                    "ROMarr is not configured yet.\n\n" +
+                    "Create romarr.json beside this plugin:\n" +
+                    "{ \"url\": \"http://romarr:6868\", \"apiKey\": \"...\" }",
+                    "ROMarr");
+                return;
+            }
+
+            try
+            {
+                var xml = Fetch(settings).GetAwaiter().GetResult();
+                var added = Import(xml);
+                MessageBox.Show($"ROMarr: added {added} games.", "ROMarr");
+            }
+            catch (Exception exception)
+            {
+                // Surfaced rather than swallowed: a sync that silently does
+                // nothing is indistinguishable from an empty library, and the
+                // operator debugs the wrong end of it.
+                MessageBox.Show("ROMarr sync failed:\n" + exception.Message, "ROMarr");
+            }
+        }
+
+        private static async Task<string> Fetch(ROMarrSettings settings)
+        {
+            using (var client = new HttpClient())
+            {
+                client.Timeout = TimeSpan.FromMinutes(5);
+                // The key is a header, never a query parameter. LaunchBox
+                // writes its own logs and a key in a URL ends up in them.
+                client.DefaultRequestHeaders.Add("X-Api-Key", settings.ApiKey);
+                client.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue("application/xml"));
+
+                var uri = settings.Url.TrimEnd('/') +
+                          "/api/v1/frontend/export?format=launchbox";
+                var response = await client.GetAsync(uri).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+        }
+
+        private static int Import(string xml)
+        {
+            var document = XDocument.Parse(xml);
+            var platforms = PluginHelper.DataManager.GetAllPlatforms()
+                .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+            // Index what is already here by launch path. Re-running a sync
+            // must update rather than duplicate -- an importer that doubles
+            // the library on every run is the most common complaint about
+            // tools in this shape.
+            var known = new HashSet<string>(
+                PluginHelper.DataManager.GetAllGames()
+                    .Where(g => !string.IsNullOrWhiteSpace(g.ApplicationPath))
+                    .Select(g => g.ApplicationPath),
+                StringComparer.OrdinalIgnoreCase);
+
+            var added = 0;
+            foreach (var element in document.Descendants("Game"))
+            {
+                var path = (string)element.Element("ApplicationPath");
+                var title = (string)element.Element("Title");
+                var platformName = (string)element.Element("Platform");
+
+                if (string.IsNullOrWhiteSpace(path) ||
+                    string.IsNullOrWhiteSpace(title) ||
+                    known.Contains(path))
+                {
+                    continue;
+                }
+
+                // A platform LaunchBox does not have is created rather than
+                // skipped: dropping the game would lose it silently, and the
+                // operator would have no idea which ones went missing.
+                if (!platforms.ContainsKey(platformName))
+                {
+                    var created = PluginHelper.DataManager.AddNewPlatform(platformName);
+                    platforms[platformName] = created;
+                }
+
+                var game = PluginHelper.DataManager.AddNewGame(title);
+                game.ApplicationPath = path;
+                game.Platform = platformName;
+                game.Notes = (string)element.Element("Notes") ?? string.Empty;
+                added++;
+            }
+
+            if (added > 0)
+            {
+                PluginHelper.DataManager.Save(true);
+            }
+            return added;
+        }
+    }
+
+    internal class ROMarrSettings
+    {
+        public string Url { get; set; }
+        public string ApiKey { get; set; }
+
+        public static ROMarrSettings Load()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetDirectoryName(
+                    System.Reflection.Assembly.GetExecutingAssembly().Location),
+                "romarr.json");
+            if (!System.IO.File.Exists(path)) return null;
+
+            var text = System.IO.File.ReadAllText(path);
+            var settings = new ROMarrSettings
+            {
+                Url = Between(text, "\"url\""),
+                ApiKey = Between(text, "\"apiKey\""),
+            };
+            return string.IsNullOrWhiteSpace(settings.Url) ? null : settings;
+        }
+
+        // Deliberately not a JSON library. The file has two string fields and
+        // adding a NuGet dependency to a plugin that must be dropped into
+        // someone's LaunchBox folder as a single DLL is a poor trade.
+        private static string Between(string text, string key)
+        {
+            var at = text.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+            if (at < 0) return null;
+            var colon = text.IndexOf(':', at);
+            if (colon < 0) return null;
+            var open = text.IndexOf('"', colon);
+            if (open < 0) return null;
+            var close = text.IndexOf('"', open + 1);
+            return close < 0 ? null : text.Substring(open + 1, close - open - 1);
+        }
+    }
+}

--- a/contrib/playnite/ROMarr/ROMarr.psm1
+++ b/contrib/playnite/ROMarr/ROMarr.psm1
@@ -1,0 +1,123 @@
+# ROMarr -> Playnite
+#
+# A Generic script extension: no compilation, installs by copying this folder
+# into %APPDATA%\Playnite\Extensions\.
+#
+# Playnite's Library plugin interface -- the one that makes a source appear
+# alongside Steam and GOG -- is C# only. A menu item imports the same games
+# without requiring a build toolchain, which is the trade this makes
+# deliberately: something you can install and read, over something you must
+# compile.
+
+function GetMainMenuItems {
+    param($menuArgs)
+
+    $sync = New-Object Playnite.SDK.Plugins.ScriptMainMenuItem
+    $sync.Description = "Sync library"
+    $sync.FunctionName = "Invoke-ROMarrSync"
+    $sync.MenuSection = "@ROMarr"
+
+    $configure = New-Object Playnite.SDK.Plugins.ScriptMainMenuItem
+    $configure.Description = "Configure"
+    $configure.FunctionName = "Invoke-ROMarrConfigure"
+    $configure.MenuSection = "@ROMarr"
+
+    return @($sync, $configure)
+}
+
+function Get-ROMarrConfigPath {
+    return Join-Path $CurrentExtensionInstallPath "romarr.config.json"
+}
+
+function Get-ROMarrConfig {
+    $path = Get-ROMarrConfigPath
+    if (Test-Path $path) {
+        return Get-Content $path -Raw | ConvertFrom-Json
+    }
+    return $null
+}
+
+function Invoke-ROMarrConfigure {
+    param($scriptArgs)
+
+    $url = $PlayniteApi.Dialogs.SelectString(
+        "ROMarr URL (e.g. http://romarr:6868)", "ROMarr", "http://localhost:6868")
+    if (-not $url.Result) { return }
+
+    $key = $PlayniteApi.Dialogs.SelectString(
+        "API key (Settings -> General in ROMarr)", "ROMarr", "")
+    if (-not $key.Result) { return }
+
+    @{ url = $url.SelectedString.TrimEnd('/'); apiKey = $key.SelectedString } |
+        ConvertTo-Json | Set-Content -Path (Get-ROMarrConfigPath) -Encoding UTF8
+
+    $PlayniteApi.Dialogs.ShowMessage("Saved. Extensions -> ROMarr -> Sync library.", "ROMarr")
+}
+
+function Invoke-ROMarrSync {
+    param($scriptArgs)
+
+    $config = Get-ROMarrConfig
+    if ($null -eq $config) {
+        $PlayniteApi.Dialogs.ShowErrorMessage(
+            "Not configured yet. Extensions -> ROMarr -> Configure.", "ROMarr")
+        return
+    }
+
+    $uri = "$($config.url)/api/v1/frontend/export?format=playnite"
+    try {
+        # The key goes in a header, never the query string: Playnite logs the
+        # URLs it fetches, and a key in a log is a key on somebody's pastebin.
+        $response = Invoke-RestMethod -Uri $uri -Headers @{ "X-Api-Key" = $config.apiKey } `
+                                      -TimeoutSec 120 -ErrorAction Stop
+    } catch {
+        $PlayniteApi.Dialogs.ShowErrorMessage(
+            "Could not reach ROMarr: $($_.Exception.Message)", "ROMarr")
+        return
+    }
+
+    if ($null -eq $response.games) {
+        $PlayniteApi.Dialogs.ShowErrorMessage("ROMarr returned no games.", "ROMarr")
+        return
+    }
+
+    # Index what Playnite already has, so a re-sync updates rather than
+    # duplicating. Without this every sync doubles the library, which is the
+    # single most common complaint about importers like this one.
+    $existing = @{}
+    foreach ($game in $PlayniteApi.Database.Games) {
+        if ($game.GameId -and $game.PluginId -eq [guid]::Empty) {
+            $existing[$game.GameId] = $game
+        }
+    }
+
+    $added = 0
+    $skipped = 0
+    foreach ($entry in $response.games) {
+        if ([string]::IsNullOrWhiteSpace($entry.romPath)) { $skipped++; continue }
+        $gameId = "romarr:$($entry.id)"
+        if ($existing.ContainsKey($gameId)) { $skipped++; continue }
+
+        $game = New-Object "Playnite.SDK.Models.Game"
+        $game.Name = $entry.name
+        $game.GameId = $gameId
+        $game.IsInstalled = $true
+
+        $action = New-Object "Playnite.SDK.Models.GameAction"
+        $action.Type = [Playnite.SDK.Models.GameActionType]::File
+        $action.Path = $entry.romPath
+        $action.IsPlayAction = $true
+        $game.GameActions = [System.Collections.ObjectModel.ObservableCollection[Playnite.SDK.Models.GameAction]]::new()
+        $game.GameActions.Add($action)
+
+        if ($entry.verified -eq "verified") {
+            $game.Notes = "ROMarr: verified against DAT"
+        }
+
+        $PlayniteApi.Database.Games.Add($game)
+        $added++
+    }
+
+    $PlayniteApi.Dialogs.ShowMessage(
+        "ROMarr: added $added, already present or unplayable $skipped.", "ROMarr")
+}

--- a/contrib/playnite/ROMarr/extension.yaml
+++ b/contrib/playnite/ROMarr/extension.yaml
@@ -1,0 +1,10 @@
+Id: ROMarr_9f1c4a2e
+Name: ROMarr
+Author: BlizzHacker
+Version: 1.0.0
+Module: ROMarr.psm1
+Type: Script
+Icon: icon.png
+Links:
+  - Name: Source
+    Url: https://github.com/BlizzHacker/romarr

--- a/docs/proposals/romm-local-dat-metadata.md
+++ b/docs/proposals/romm-local-dat-metadata.md
@@ -1,0 +1,119 @@
+# Proposal: offline metadata identification from local DAT files
+
+Submitted upstream to [RomM](https://github.com/rommapp/romm) as a gift from
+the Cartridge project. The same proposal suits Gaseous and Retrom, which have
+the same gap.
+
+## The gap, stated against what RomM already has
+
+RomM already identifies ROMs by hash, and does it well. `hasheous_handler.py`
+sends CRC/MD5/SHA1 to [Hasheous](https://hasheous.org) and
+`playmatch_handler.py` uses IGDB's PlayMatch. Both are better than filename
+matching and this proposal does not replace either.
+
+Both are also **network services**. That means hash identification today:
+
+- requires the server to reach a third party, so it does not work on an
+  airgapped or LAN-only install;
+- depends on that service staying up, staying free, and not rate-limiting a
+  first scan of a large library;
+- cannot be verified or audited locally — you get an answer, not a reason.
+
+There is no offline path. `grep -rl "no-intro\|logiqx\|datfile" backend/`
+returns nothing relevant.
+
+## The proposal
+
+Add a metadata handler that reads **local Logiqx DAT files** — the format
+No-Intro and Redump publish — and identifies a ROM by looking its hash up in
+them.
+
+This is not a new idea in the preservation world; it is what RomVault, Igir
+and clrmamepro have done for twenty years. It is new *to this class of
+application*, and it composes with what RomM has rather than competing:
+
+```
+hash -> local DAT      (offline, exact, auditable)   <- proposed
+     -> Hasheous       (online, broad)               <- exists
+     -> PlayMatch      (online, IGDB-linked)         <- exists
+     -> filename       (fallback)                    <- exists
+```
+
+Three things fall out of it that RomM cannot currently do:
+
+1. **Identification with no network at all.** The DATs are files the operator
+   already has or can fetch once.
+2. **A verification verdict, not just a name.** A DAT says what the correct
+   dump *is*, so a file can be reported as `verified`, `bad-dump` (right size,
+   wrong checksum — corrupt or patched) or `unknown`. RomM currently has no
+   way to tell a user that a ROM in their library is corrupt.
+3. **An exact metadata key.** A verified file has a canonical No-Intro name,
+   so the subsequent IGDB/Moby/SS lookup can be keyed on `Chrono Trigger`
+   rather than on whatever `Chrono.Trigger.USA.Retranslated.v1.2.[!].smc`
+   parses to. This is where most wrong cover art comes from, and it fails
+   silently — a cover for the wrong game looks exactly like a cover for the
+   right one.
+
+## Reference implementation
+
+Working, tested Python, AGPL-compatible, and free to take wholesale:
+
+- [`romarr/dat.py`](https://github.com/BlizzHacker/romarr/blob/main/romarr/dat.py)
+  — Logiqx parser, hash index, 1G1R, ~330 lines
+- [`romarr/metadata.py`](https://github.com/BlizzHacker/romarr/blob/main/romarr/metadata.py)
+  — the "verified name becomes the lookup key" part
+- [`tests/test_dat.py`](https://github.com/BlizzHacker/romarr/blob/main/tests/test_dat.py)
+  — 28 tests including the traps below
+
+### The traps, because they are the whole difficulty
+
+Anyone implementing this will hit these, and each one produces a feature that
+looks broken rather than one that looks wrong:
+
+**Copier headers.** No-Intro hashes cartridge *contents*. iNES (16 bytes),
+fwNES (16), Lynx (64) and Atari 7800 (128) headers are added afterwards, and a
+Super Nintendo dump may or may not carry a 512-byte copier header with nothing
+in the extension to say which. Hash the file as it sits and you get a checksum
+that appears in no DAT ever published — so every NES and SNES ROM comes back
+`unknown` and the feature looks useless. The SNES rule is arithmetic:
+cartridge data is a whole number of 32 KB banks, so a file 512 bytes over a
+multiple of 32768 is headered.
+
+**Discs are sets.** Redump lists every track of a disc as its own `<rom>`, so
+a `.cue` with a correct checksum beside a corrupt `.bin` is not a good dump.
+Judging the set by its first member misses exactly the case worth catching.
+
+**`unknown` is not `bad`.** Absence from a DAT means homebrew, a translation,
+a new release, or an out-of-date DAT. Treating absence as corruption would
+have RomM telling users their perfectly good files are broken.
+
+**SHA1 over CRC32 where both exist.** CRC32 is 32 bits and collides; across a
+full DAT collection that stops being theoretical.
+
+**Stream the hash.** A PS2 image is several gigabytes. Deciding whether to
+skip a 512-byte header must be done from the file's *length*, not by reading
+it — that mistake reintroduces a full-file buffer one line above the chunked
+hashing that exists to prevent it.
+
+## Why this is being offered rather than built as a plugin
+
+Cartridge maintains [ROM Hub](https://github.com/BlizzHacker/rom-hub), a
+plugin host that sits beside a library server and never modifies it, and this
+could live there. It is being offered upstream because identification is a
+property of the library rather than of a tool beside it: a ROM that RomM knows
+is a verified No-Intro dump is more useful to *every* RomM client — the web
+UI, the mobile apps, EmulatorJS — than one that only ROMarr knows about.
+
+If it is not wanted upstream, that is a completely reasonable answer and no
+follow-up is needed; ROM Hub will expose it through its `metadata` capability
+instead.
+
+## Scope
+
+Deliberately small. One handler, one settings block pointing at a DAT
+directory, one nullable `verification_status` on the ROM model. No UI beyond
+surfacing the verdict where the hash is already shown, no changes to existing
+handlers, and no new runtime dependency — the DAT format is XML and hashing is
+`hashlib` and `zlib`.
+
+Happy to open the PR if there is interest in the shape.

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -49,6 +49,7 @@ from .libraries import (
 )
 from .clients import QBittorrent, QbitConfig, Romm, RommConfig
 from . import hub  # ROM Hub bridge -- the Cartridge plugin layer
+from .dat import DatIndex, parse_dat
 from .downloaders import (
     CLIENT_TYPES, NZBGet, NzbgetConfig, SABnzbd, SabConfig, build_client,
     merge_secrets, pick_client, redact,
@@ -61,6 +62,11 @@ from .auth import SESSION_COOKIE, Auth, new_api_key, parse_cookies
 from .catalogue import (Submission, check_source, facets as hub_facets,
                         search as hub_search, submission_link)
 from .frontends import FORMATS as FRONTEND_FORMATS
+from .metadata import PROVIDERS as METADATA_PROVIDERS
+from .notify import NOTIFIERS, Message, Notifier, failed, grabbed, imported
+from .profiles import Blocklist, ReleaseProfile, release_id
+from .upgrade import is_upgrade, merge_tags, scan as scan_directory
+from .metadata import Metadata, calendar as metadata_calendar
 from .ops import RateLimiter, make_backup, read_backup, render_metrics, to_csv
 from .platforms import PLATFORMS, resolve
 from .sso import ForwardAuth
@@ -252,6 +258,10 @@ class ROMarr:
         # verifies the request came *through* it, learns who the user is, and
         # can require a group.
         self.limiter = RateLimiter()
+        self.reload_dats(e.get("DAT_PATH", "")
+                         or self.store.settings.get("dat_path", ""))
+        self.reload_metadata()
+        self.reload_policy()
         self.sso = None
         if mode == "forward":
             self.sso = ForwardAuth(
@@ -1126,6 +1136,115 @@ class ROMarr:
             "uptime": f"{up // 3600}h {(up % 3600) // 60}m",
         }
 
+    def reload_dats(self, directory: str = "") -> dict:
+        """Load every DAT under `directory`.
+
+        Optional and quiet. An operator with no DATs is the common case on
+        day one, and it must not turn every import into an error -- the index
+        simply answers `unknown`, which is a real verdict rather than a
+        failure.
+        """
+        self.dats = DatIndex()
+        self.store.settings["dat_path"] = str(directory or "")
+        if not directory:
+            return {"loaded": 0, "path": ""}
+        root = Path(directory)
+        if not root.is_dir():
+            log.warning("DAT_PATH %s is not a directory", root)
+            return {"loaded": 0, "path": str(root),
+                    "error": f"{root} is not a directory"}
+        for path in sorted(root.rglob("*.dat")) + sorted(root.rglob("*.xml")):
+            try:
+                self.dats.add(parse_dat(path.read_text(encoding="utf-8",
+                                                       errors="replace")))
+            except OSError as exc:
+                log.warning("could not read %s: %s", path, exc)
+        log.info("loaded %d DAT(s) from %s", len(self.dats.dats), root)
+        return {"loaded": len(self.dats.dats), "path": str(root)}
+
+    def reload_policy(self) -> None:
+        """Rebuild the operator's selection policy and notification fan-out.
+
+        Held on the service rather than rebuilt per search: a blocklist is
+        read on every candidate, and re-parsing it thousands of times during
+        one interactive search is work nobody asked for.
+        """
+        self.profile = ReleaseProfile.from_settings(self.store.settings)
+        self.blocklist = Blocklist.from_items(
+            self.store.list_items("blocklist"))
+        self.notifier = Notifier(self.store.list_items("connections"))
+
+    def block(self, release, reason: str = "") -> dict:
+        """Never take this release again, and record why."""
+        entry = self.blocklist.add(release, reason=reason)
+        self.store.put_item("blocklist", entry)
+        return entry
+
+    def unblock(self, entry_id: str) -> bool:
+        self.blocklist.remove(entry_id)
+        return self.store.delete_item("blocklist", entry_id)
+
+    def notify(self, message) -> list[dict]:
+        """Fan out, and never let a failure here matter.
+
+        The delivery is a courtesy; the import is the work.
+        """
+        try:
+            return self.notifier.send(message)
+        except Exception as exc:
+            log.warning("notification fan-out failed: %s", exc)
+            return []
+
+    def tag(self, item_id: str, add=None, remove=None) -> list[str]:
+        """Set the tags on one library item."""
+        tags = self.store.settings.setdefault("_tags", {})
+        merged = merge_tags(tags.get(str(item_id)) or [], add, remove)
+        if merged:
+            tags[str(item_id)] = merged
+        else:
+            tags.pop(str(item_id), None)
+        self.store.save()
+        return merged
+
+    def tags_for(self, item_id: str) -> list[str]:
+        return list((self.store.settings.get("_tags") or {}).get(str(item_id))
+                    or [])
+
+    def scan(self, directory: str) -> dict:
+        """Manual import: what is already on disk that ROMarr could adopt."""
+        result = scan_directory(directory, PLATFORMS, self.dats)
+        return {
+            "candidates": [vars(c) for c in result.candidates],
+            "skipped": result.skipped,
+            "error": result.error,
+        }
+
+    def reload_metadata(self) -> None:
+        """Rebuild the provider chain from stored settings."""
+        self.metadata = Metadata(self.store.list_items("metadata_providers"))
+
+    def identify(self, filename: str = "", verification=None) -> dict:
+        """Name a game, and say how confidently.
+
+        `matched_by` travels with the answer because "we matched a DAT name"
+        and "we guessed from the filename" deserve different amounts of trust.
+        A UI that shows a cover without saying which is inviting somebody to
+        believe the wrong one.
+        """
+        info = self.metadata.identify(verification=verification,
+                                      filename=filename)
+        return {
+            "found": info.found,
+            "title": info.title,
+            "summary": info.summary,
+            "released": info.released,
+            "rating": info.rating,
+            "genres": list(info.genres),
+            "cover_url": info.cover_url,
+            "source": info.source,
+            "matched_by": info.matched_by,
+        }
+
     def frontend_rows(self, platform: str = "") -> list[dict]:
         """The library flattened into the shape every frontend export wants.
 
@@ -1540,6 +1659,32 @@ def make_handler(service: ROMarr):
                     "matched": len(found),
                     "error": catalogue.get("error"),
                 })
+            if route.path == "/api/v1/calendar":
+                return self._json(200, metadata_calendar(
+                    service.store.list_items("metadata_providers"),
+                    days_back=int(query.get("back", ["30"])[0] or 30),
+                    days_ahead=int(query.get("ahead", ["60"])[0] or 60)))
+            if route.path == "/api/v1/blocklist":
+                return self._json(200, {"items": service.blocklist.as_items()})
+            if route.path == "/api/v1/connection/schema":
+                return self._json(200, {"types": [
+                    {"name": name, "label": spec["label"],
+                     "fields": list(spec["fields"]), "help": spec["help"]}
+                    for name, spec in NOTIFIERS.items()]})
+            if route.path == "/api/v1/tag":
+                return self._json(200, {
+                    "tags": service.store.settings.get("_tags") or {}})
+            if route.path == "/api/v1/manualimport":
+                return self._json(200, service.scan(
+                    query.get("path", [""])[0]))
+            if route.path == "/api/v1/metadata/schema":
+                return self._json(200, {"providers": [
+                    {"name": name, "label": spec["label"],
+                     "fields": list(spec["fields"]), "help": spec["help"]}
+                    for name, spec in METADATA_PROVIDERS.items()]})
+            if route.path == "/api/v1/metadata/lookup":
+                return self._json(200, service.identify(
+                    filename=query.get("filename", [""])[0]))
             if route.path == "/api/v1/frontend/formats":
                 return self._json(200, {"formats": [
                     {"name": name, "label": spec["label"],
@@ -1608,6 +1753,19 @@ def make_handler(service: ROMarr):
             except json.JSONDecodeError:
                 return self._json(400, {"error": "invalid json"})
 
+            if route.path == "/api/v1/blocklist":
+                # A release is blocked by identity, so a title the indexer
+                # rewrites tomorrow is still the same block.
+                from .selection import Release as _Release
+
+                release = _Release(
+                    title=str(body.get("title") or ""),
+                    size=int(body.get("size") or 0), seeders=0,
+                    categories=(), download_url=str(body.get("url") or ""),
+                    protocol="torrent",
+                    indexer=str(body.get("indexer") or ""))
+                return self._json(200, service.block(
+                    release, str(body.get("reason") or "")))
             if route.path == "/api/v1/restore":
                 try:
                     settings, warning = read_backup(body)
@@ -1650,6 +1808,17 @@ def make_handler(service: ROMarr):
                 self.send_header("Content-Length", str(len(payload)))
                 self.end_headers()
                 return self.wfile.write(payload)
+            if route.path == "/api/v1/connection/test":
+                got = service.notify(Message(
+                    "grab", "ROMarr test notification",
+                    body="If you can read this, the connection works.",
+                    reasons=("+50 this is a test",)))
+                return self._json(200, {"results": got})
+            if route.path == "/api/v1/tag":
+                merged = service.tag(str(body.get("id") or ""),
+                                     add=body.get("add"),
+                                     remove=body.get("remove"))
+                return self._json(200, {"tags": merged})
             if route.path == "/api/v1/hub/submit":
                 # Prepared, never sent. Publishing under somebody's name is
                 # their decision; a tool that posts because a button was

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -58,6 +58,7 @@ from .indexers import Prowlarr, ProwlarrConfig
 from .library import import_rom, map_remote_path
 from .auth import DISABLED as AUTH_DISABLED
 from .auth import SESSION_COOKIE, Auth, new_api_key, parse_cookies
+from .ops import RateLimiter, make_backup, read_backup, render_metrics, to_csv
 from .platforms import PLATFORMS, resolve
 from .sso import ForwardAuth
 from .totp import Totp
@@ -247,6 +248,7 @@ class ROMarr:
         # proxy entirely. Forward mode keeps the proxy as the authority but
         # verifies the request came *through* it, learns who the user is, and
         # can require a group.
+        self.limiter = RateLimiter()
         self.sso = None
         if mode == "forward":
             self.sso = ForwardAuth(
@@ -1121,6 +1123,23 @@ class ROMarr:
             "uptime": f"{up // 3600}h {(up % 3600) // 60}m",
         }
 
+    def metrics(self) -> str:
+        """Everything a scrape needs, from state already computed."""
+        up = int(time.monotonic() - self._started)
+        return render_metrics({
+            "platforms": len(PLATFORMS),
+            "queued": len(self.queue),
+            "wanted": len(self.store.missing()),
+            "blocklist": len(self.store.list_items("blocklist")),
+            "uptime_seconds": up,
+            "dependencies": {
+                "prowlarr": bool(self.prowlarr._config.api_key),
+                **{lib["name"]: bool(lib.get("ok"))
+                   for lib in self.libraries_status()},
+            },
+            "imports": self.store.settings.get("_import_verdicts") or {},
+        })
+
     def play_route_counts(self) -> dict:
         """How many supported platforms are playable, and by which route.
 
@@ -1325,6 +1344,21 @@ def make_handler(service: ROMarr):
         #: than the library paths and client URLs it used to hand out for free.
         OPEN_PATHS = ("/", "/api/health", "/api/v1/login")
 
+        def _drain(self) -> None:
+            """Read the request body before refusing it.
+
+            A POST has already sent its body; replying without reading leaves
+            those bytes in the socket and the client sees an aborted
+            connection rather than the refusal. The refusal has to arrive to
+            be useful.
+            """
+            try:
+                length = int(self.headers.get("Content-Length") or 0)
+                if length > 0:
+                    self.rfile.read(length)
+            except (ValueError, OSError):
+                pass
+
         def _authorised(self) -> bool:
             # Single sign-on first, when configured. `self.client_address` is
             # the socket peer -- the only trustworthy source. Reading it from
@@ -1349,21 +1383,31 @@ def make_handler(service: ROMarr):
             downloads end up answering strangers.
             """
             path = urlparse(self.path).path
+            # Rate limit before authenticating, and key on the caller's
+            # address: login is the one endpoint where guessing is the attack,
+            # so it has to be limited for callers who have not authenticated
+            # -- which is all of them, at that point.
+            category = RateLimiter.category_for(path)
+            allowed, retry = service.limiter.check(
+                category, self.client_address[0])
+            if not allowed:
+                # Drain first, for the same reason the 401 does: a POST has
+                # already sent its body, and replying without reading it
+                # aborts the connection so the caller never sees the 429 --
+                # which is precisely the caller who most needs to be told to
+                # slow down, and who will otherwise retry immediately.
+                self._drain()
+                self.send_response(429)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Retry-After", str(retry))
+                body = json.dumps({"error": "rate limited",
+                                   "retry_after": retry}).encode()
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                return self.wfile.write(body)
             if path in self.OPEN_PATHS or self._authorised():
                 return self._guard(handler)
-            # Drain the request body before refusing.
-            #
-            # A POST or PUT has already sent its body; replying without
-            # reading it leaves those bytes in the socket, and the client sees
-            # its connection aborted rather than the 401. The refusal has to
-            # arrive to be useful -- an unauthenticated caller that cannot
-            # tell "refused" from "network broke" will retry forever.
-            try:
-                length = int(self.headers.get("Content-Length") or 0)
-                if length > 0:
-                    self.rfile.read(length)
-            except (ValueError, OSError):
-                pass
+            self._drain()
             return self._json(401, {
                 "error": "unauthorised",
                 "detail": "Send your key as the X-Api-Key header, as "
@@ -1421,6 +1465,30 @@ def make_handler(service: ROMarr):
                 return self._json(200, {"items": service.download_clients()})
             if route.path == "/api/v1/downloadclient/schema":
                 return self._json(200, {"types": CLIENT_TYPES})
+            if route.path == "/metrics":
+                # Authenticated like everything else. A metrics endpoint that
+                # is open while the rest of the app is not is a hole with a
+                # Grafana dashboard attached: it names every dependency, the
+                # queue depth and the library size.
+                return self._send(200, service.metrics().encode(),
+                                  "text/plain; version=0.0.4; charset=utf-8")
+            if route.path == "/api/v1/backup":
+                include = query.get("secrets", ["0"])[0] in ("1", "true", "yes")
+                return self._json(200, make_backup(service.store.settings,
+                                                   include_secrets=include))
+            if route.path == "/api/v1/export":
+                what = (query.get("what", ["library"])[0] or "library").lower()
+                rows = {
+                    "library": service.library_view().get("items", []),
+                    "wanted": service.store.missing(),
+                    "blocklist": service.store.list_items("blocklist"),
+                }.get(what)
+                if rows is None:
+                    return self._json(400, {"error": "unknown export"})
+                if query.get("format", ["json"])[0].lower() == "csv":
+                    return self._send(200, to_csv(rows).encode(),
+                                      "text/csv; charset=utf-8")
+                return self._json(200, {"items": rows})
             if route.path == "/api/v1/indexer/schema":
                 return self._json(200, {"types": INDEXER_TYPES})
             if route.path == "/api/v1/library":
@@ -1474,6 +1542,16 @@ def make_handler(service: ROMarr):
             except json.JSONDecodeError:
                 return self._json(400, {"error": "invalid json"})
 
+            if route.path == "/api/v1/restore":
+                try:
+                    settings, warning = read_backup(body)
+                except ValueError as exc:
+                    return self._json(400, {"error": str(exc)})
+                service.store.settings.update(settings)
+                service.store.save()
+                service.reload_clients()
+                service.reload_libraries()
+                return self._json(200, {"ok": True, "warning": warning})
             if route.path == "/api/v1/login":
                 # Exchange a credential for a session, so a browser presents
                 # the key once instead of carrying it in every request and

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -56,6 +56,8 @@ from .downloaders import (
 from .indexers import INDEXER_TYPES, build_indexer, redact_indexer
 from .indexers import Prowlarr, ProwlarrConfig
 from .library import import_rom, map_remote_path
+from .auth import DISABLED as AUTH_DISABLED
+from .auth import SESSION_COOKIE, Auth, new_api_key, parse_cookies
 from .platforms import PLATFORMS, resolve
 from .playability import DOWNLOAD, StreamServer, routes_for
 from .selection import best_release, judge, score
@@ -210,6 +212,25 @@ class ROMarr:
         stream_url = e.get("STREAM_SERVER_URL", "")
         self.store.settings["_stream_url"] = stream_url
         self.stream = StreamServer(stream_url) if stream_url else None
+
+        # Authentication, on unless deliberately turned off.
+        #
+        # The key is generated and stored on first run rather than left blank,
+        # because an install that is open until somebody reads the
+        # documentation is an open install. It is kept under a leading
+        # underscore so `safe_settings` never has to learn about it -- that
+        # method masks known credential shapes, and a key it had not been told
+        # about would have gone straight into the browser.
+        api_key = e.get("ROMARR_API_KEY", "") or self.store.settings.get("_api_key", "")
+        if not api_key:
+            api_key = new_api_key()
+            log.info("generated an API key; find it under Settings -> General")
+        self.store.settings["_api_key"] = api_key
+        self.auth = Auth(
+            api_key=api_key,
+            password_hash=self.store.settings.get("_password_hash", ""),
+            enabled=e.get("ROMARR_AUTH", "").strip().lower() != AUTH_DISABLED,
+        )
 
         self._seed_from_env(e)
         self.reload_clients()
@@ -563,6 +584,12 @@ class ROMarr:
         out["download_clients"] = [redact(c) for c in out.get("download_clients", [])]
         out["indexers"] = [redact_indexer(i) for i in out.get("indexers", [])]
         out["libraries"] = [redact_library(lib) for lib in out.get("libraries", [])]
+        # The two settings that ARE the credential. Removed by name rather
+        # than by a leading-underscore rule, because the other underscore keys
+        # (`_prowlarr_url`, `_romm_url`, `_stream_url`) are deliberately shown
+        # -- a rule would have hidden the wrong half of them.
+        for secret in ("_api_key", "_password_hash"):
+            out.pop(secret, None)
         return out
 
     # --- inbound webhooks -------------------------------------------------
@@ -1257,17 +1284,62 @@ def make_handler(service: ROMarr):
                 log.exception("%s %s failed", self.command, self.path)
                 return self._json(500, {"error": f"{type(exc).__name__}: {exc}"})
 
+        #: Paths that answer without a credential, and nothing else.
+        #:
+        #: `/` is the UI shell, which holds no data and is where somebody logs
+        #: in. `/api/v1/login` is how they do it. `/api/health` is the
+        #: container's HEALTHCHECK, which has no credential to offer -- it
+        #: answers, but see `_get`: unauthenticated it returns one bit rather
+        #: than the library paths and client URLs it used to hand out for free.
+        OPEN_PATHS = ("/", "/api/health", "/api/v1/login")
+
+        def _authorised(self) -> bool:
+            cookies = parse_cookies(self.headers.get("Cookie", ""))
+            query = parse_qs(urlparse(self.path).query)
+            return service.auth.authorised(self.headers, query, cookies)
+
+        def _gate(self, handler):
+            """Refuse before doing anything, unless the path is open.
+
+            Wrapped around every verb rather than checked inside each route:
+            a route added later is protected by default, and forgetting to
+            call a per-route check is exactly how the endpoints that queue
+            downloads end up answering strangers.
+            """
+            path = urlparse(self.path).path
+            if path in self.OPEN_PATHS or self._authorised():
+                return self._guard(handler)
+            # Drain the request body before refusing.
+            #
+            # A POST or PUT has already sent its body; replying without
+            # reading it leaves those bytes in the socket, and the client sees
+            # its connection aborted rather than the 401. The refusal has to
+            # arrive to be useful -- an unauthenticated caller that cannot
+            # tell "refused" from "network broke" will retry forever.
+            try:
+                length = int(self.headers.get("Content-Length") or 0)
+                if length > 0:
+                    self.rfile.read(length)
+            except (ValueError, OSError):
+                pass
+            return self._json(401, {
+                "error": "unauthorised",
+                "detail": "Send your key as the X-Api-Key header, as "
+                          "Authorization: Bearer, or as ?apikey=. Find it "
+                          "under Settings -> General, or set ROMARR_API_KEY.",
+            })
+
         def do_GET(self):
-            return self._guard(self._get)
+            return self._gate(self._get)
 
         def do_POST(self):
-            return self._guard(self._post)
+            return self._gate(self._post)
 
         def do_PUT(self):
-            return self._guard(self._put)
+            return self._gate(self._put)
 
         def do_DELETE(self):
-            return self._guard(self._delete)
+            return self._gate(self._delete)
 
         def _get(self):
             route = urlparse(self.path)
@@ -1322,6 +1394,13 @@ def make_handler(service: ROMarr):
                 return self._json(200, service.status())
             if route.path == "/api/v1/system/counts":
                 return self._json(200, service.counts())
+            if route.path == "/api/health" and not self._authorised():
+                # Liveness needs one bit. The full report names library paths,
+                # client URLs and counts, and this endpoint is reachable
+                # without a credential so the container HEALTHCHECK works --
+                # which made all of that free reconnaissance for anyone who
+                # could reach the port.
+                return self._json(200, {"ok": True})
             if route.path == "/api/health":
                 return self._json(200, service.health())
             if route.path == "/api/platforms":
@@ -1353,6 +1432,30 @@ def make_handler(service: ROMarr):
             except json.JSONDecodeError:
                 return self._json(400, {"error": "invalid json"})
 
+            if route.path == "/api/v1/login":
+                # Exchange a credential for a session, so a browser presents
+                # the key once instead of carrying it in every request and
+                # holding it in the page where any script can read it.
+                supplied = str(body.get("apikey") or "")
+                password = str(body.get("password") or "")
+                if not (service.auth.check_key(supplied)
+                        or service.auth.check_password(password)):
+                    return self._json(401, {"error": "unauthorised"})
+                token = service.auth.issue_session()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                # HttpOnly so a script cannot read it; SameSite=Strict so
+                # another site cannot ride it; Path=/ so it covers the API.
+                # Not Secure: ROMarr is normally plain http on a LAN, and a
+                # Secure cookie would simply never be stored there.
+                self.send_header(
+                    "Set-Cookie",
+                    f"{SESSION_COOKIE}={token}; HttpOnly; SameSite=Strict; "
+                    f"Path=/; Max-Age={service.auth.session_seconds}")
+                payload = json.dumps({"ok": True}).encode()
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                return self.wfile.write(payload)
             if route.path == "/api/v1/hub/plugin":
                 slug = (body.get("slug") or "").strip()
                 action = (body.get("action") or "").strip()

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -58,6 +58,8 @@ from .indexers import Prowlarr, ProwlarrConfig
 from .library import import_rom, map_remote_path
 from .auth import DISABLED as AUTH_DISABLED
 from .auth import SESSION_COOKIE, Auth, new_api_key, parse_cookies
+from .catalogue import (Submission, check_source, facets as hub_facets,
+                        search as hub_search, submission_link)
 from .frontends import FORMATS as FRONTEND_FORMATS
 from .ops import RateLimiter, make_backup, read_backup, render_metrics, to_csv
 from .platforms import PLATFORMS, resolve
@@ -1520,6 +1522,24 @@ def make_handler(service: ROMarr):
                     return self._send(200, to_csv(rows).encode(),
                                       "text/csv; charset=utf-8")
                 return self._json(200, {"items": rows})
+            if route.path == "/api/v1/hub/catalogue":
+                catalogue = hub.plugins()
+                items = catalogue.get("items") or []
+                found = hub_search(
+                    items,
+                    query.get("q", [""])[0],
+                    capability=query.get("capability", [""])[0],
+                    platform=query.get("platform", [""])[0],
+                    installed={"1": True, "0": False}.get(
+                        query.get("installed", [""])[0]),
+                )
+                return self._json(200, {
+                    "items": found,
+                    "facets": hub_facets(items),
+                    "total": len(items),
+                    "matched": len(found),
+                    "error": catalogue.get("error"),
+                })
             if route.path == "/api/v1/frontend/formats":
                 return self._json(200, {"formats": [
                     {"name": name, "label": spec["label"],
@@ -1630,6 +1650,37 @@ def make_handler(service: ROMarr):
                 self.send_header("Content-Length", str(len(payload)))
                 self.end_headers()
                 return self.wfile.write(payload)
+            if route.path == "/api/v1/hub/submit":
+                # Prepared, never sent. Publishing under somebody's name is
+                # their decision; a tool that posts because a button was
+                # clicked in a settings page has made it for them.
+                submission = Submission(
+                    slug=str(body.get("slug") or "").strip(),
+                    name=str(body.get("name") or "").strip(),
+                    repository=str(body.get("repository") or "").strip(),
+                    author=str(body.get("author") or "").strip(),
+                    description=str(body.get("description") or "").strip(),
+                    capabilities=list(body.get("capabilities") or []),
+                    platforms=list(body.get("platforms") or []),
+                )
+                problems = submission.problems(
+                    service.store.settings.get("plugin_hosts") or None)
+                if problems:
+                    return self._json(400, {"problems": problems})
+                return self._json(200, {
+                    "entry": submission.as_entry(),
+                    "submit_url": submission_link(submission),
+                    "note": "ROMarr does not post this for you. Open the link "
+                            "to review and submit it yourself.",
+                })
+            if route.path == "/api/v1/hub/source/check":
+                got = check_source(
+                    str(body.get("url") or ""),
+                    service.store.settings.get("plugin_hosts") or None)
+                return self._json(200 if got.ok else 400, {
+                    "ok": got.ok, "url": got.url, "host": got.host,
+                    "reason": got.reason,
+                })
             if route.path == "/api/v1/hub/plugin":
                 slug = (body.get("slug") or "").strip()
                 action = (body.get("action") or "").strip()

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -59,6 +59,8 @@ from .library import import_rom, map_remote_path
 from .auth import DISABLED as AUTH_DISABLED
 from .auth import SESSION_COOKIE, Auth, new_api_key, parse_cookies
 from .platforms import PLATFORMS, resolve
+from .sso import ForwardAuth
+from .totp import Totp
 from .playability import DOWNLOAD, StreamServer, routes_for
 from .selection import best_release, judge, score
 from .store import Event, Store
@@ -226,11 +228,41 @@ class ROMarr:
             api_key = new_api_key()
             log.info("generated an API key; find it under Settings -> General")
         self.store.settings["_api_key"] = api_key
+        mode = e.get("ROMARR_AUTH", "").strip().lower()
         self.auth = Auth(
             api_key=api_key,
             password_hash=self.store.settings.get("_password_hash", ""),
-            enabled=e.get("ROMARR_AUTH", "").strip().lower() != AUTH_DISABLED,
+            enabled=mode != AUTH_DISABLED,
         )
+        self.auth.totp = Totp(
+            secret=self.store.settings.get("_totp_secret", ""),
+            backup=self.store.settings.get("_totp_backup", []) or [],
+        )
+
+        # Single sign-on, when a proxy in front is the authority.
+        #
+        # This is what `ROMARR_AUTH=disabled` should have been. That setting
+        # is honest about what it does -- ROMarr stops checking anything, so
+        # any request reaching the port is in, including one that bypassed the
+        # proxy entirely. Forward mode keeps the proxy as the authority but
+        # verifies the request came *through* it, learns who the user is, and
+        # can require a group.
+        self.sso = None
+        if mode == "forward":
+            self.sso = ForwardAuth(
+                provider=e.get("ROMARR_SSO_PROVIDER", "authentik"),
+                trusted_proxies=[p.strip() for p
+                                 in e.get("ROMARR_TRUSTED_PROXIES", "").split(",")
+                                 if p.strip()],
+                user_header=e.get("ROMARR_SSO_USER_HEADER", ""),
+                groups_header=e.get("ROMARR_SSO_GROUPS_HEADER", ""),
+                required_group=e.get("ROMARR_SSO_GROUP", ""),
+            )
+            if not self.sso.trusted_proxies:
+                log.error(
+                    "ROMARR_AUTH=forward with no ROMARR_TRUSTED_PROXIES: every "
+                    "request will be refused. Set it to the proxy's address, "
+                    "e.g. 192.168.0.0/24")
 
         self._seed_from_env(e)
         self.reload_clients()
@@ -1294,6 +1326,16 @@ def make_handler(service: ROMarr):
         OPEN_PATHS = ("/", "/api/health", "/api/v1/login")
 
         def _authorised(self) -> bool:
+            # Single sign-on first, when configured. `self.client_address` is
+            # the socket peer -- the only trustworthy source. Reading it from
+            # X-Forwarded-For would let anybody claim to be the proxy, which
+            # is the bypass the whole arrangement exists to close.
+            if service.sso is not None:
+                identity = service.sso.identify(
+                    self.headers, peer=self.client_address[0])
+                if identity.ok:
+                    return True
+                log.debug("sso refused: %s", identity.reason)
             cookies = parse_cookies(self.headers.get("Cookie", ""))
             query = parse_qs(urlparse(self.path).query)
             return service.auth.authorised(self.headers, query, cookies)
@@ -1441,6 +1483,14 @@ def make_handler(service: ROMarr):
                 if not (service.auth.check_key(supplied)
                         or service.auth.check_password(password)):
                     return self._json(401, {"error": "unauthorised"})
+                # The second factor gates the session, not the API key: a key
+                # is already a high-entropy secret and a script cannot be
+                # prompted. What 2FA protects is the interactive login.
+                if service.auth.totp.enabled and not supplied:
+                    if not service.auth.totp.verify(body.get("totp")):
+                        return self._json(401, {"error": "unauthorised",
+                                                "detail": "two-factor code "
+                                                          "required or wrong"})
                 token = service.auth.issue_session()
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -58,6 +58,7 @@ from .indexers import Prowlarr, ProwlarrConfig
 from .library import import_rom, map_remote_path
 from .auth import DISABLED as AUTH_DISABLED
 from .auth import SESSION_COOKIE, Auth, new_api_key, parse_cookies
+from .frontends import FORMATS as FRONTEND_FORMATS
 from .ops import RateLimiter, make_backup, read_backup, render_metrics, to_csv
 from .platforms import PLATFORMS, resolve
 from .sso import ForwardAuth
@@ -1123,6 +1124,36 @@ class ROMarr:
             "uptime": f"{up // 3600}h {(up % 3600) // 60}m",
         }
 
+    def frontend_rows(self, platform: str = "") -> list[dict]:
+        """The library flattened into the shape every frontend export wants.
+
+        One shape for all three, because the differences between LaunchBox,
+        Playnite and EmulationStation are in how the fields are *written*, not
+        in which fields exist -- and three near-identical row builders would
+        drift apart the first time one of them gained a column.
+        """
+        items = (self.library_view() or {}).get("items", [])
+        wanted = str(platform or "").strip().lower()
+        rows = []
+        for item in items:
+            slug = str(item.get("platform_slug") or item.get("platform") or "")
+            if wanted and slug.lower() != wanted:
+                continue
+            name = str(item.get("file_name") or item.get("filename")
+                       or item.get("name") or "")
+            rows.append({
+                "id": item.get("id") or item.get("rom_id") or "",
+                "title": item.get("name") or item.get("title") or name,
+                "platform": slug,
+                "filename": name,
+                "path": item.get("path") or item.get("full_path")
+                        or (str(self.library_root(None) / slug / name)
+                            if name and slug else ""),
+                "region": item.get("region") or "",
+                "verified": item.get("verified") or "",
+            })
+        return rows
+
     def metrics(self) -> str:
         """Everything a scrape needs, from state already computed."""
         up = int(time.monotonic() - self._started)
@@ -1489,6 +1520,21 @@ def make_handler(service: ROMarr):
                     return self._send(200, to_csv(rows).encode(),
                                       "text/csv; charset=utf-8")
                 return self._json(200, {"items": rows})
+            if route.path == "/api/v1/frontend/formats":
+                return self._json(200, {"formats": [
+                    {"name": name, "label": spec["label"],
+                     "filename": spec["filename"]}
+                    for name, spec in FRONTEND_FORMATS.items()]})
+            if route.path == "/api/v1/frontend/export":
+                name = (query.get("format", ["launchbox"])[0] or "").lower()
+                spec = FRONTEND_FORMATS.get(name)
+                if spec is None:
+                    return self._json(400, {
+                        "error": "unknown format",
+                        "known": sorted(FRONTEND_FORMATS)})
+                rows = service.frontend_rows(query.get("platform", [""])[0])
+                return self._send(200, spec["render"](rows).encode("utf-8"),
+                                  spec["content_type"])
             if route.path == "/api/v1/indexer/schema":
                 return self._json(200, {"types": INDEXER_TYPES})
             if route.path == "/api/v1/library":

--- a/romarr/auth.py
+++ b/romarr/auth.py
@@ -1,0 +1,200 @@
+"""Who is allowed to ask ROMarr to do something.
+
+There was nothing here, and `_guard` -- the only thing that looked like it
+might be a gate -- is an exception handler. So every endpoint answered anybody
+who could reach the port, including the ones that queue a torrent, write into
+the library and rewrite settings. On a home LAN that is one curl from a guest
+network or a compromised IoT device.
+
+**Secure by default, with one deliberate way out.** A key is generated on
+first run rather than left blank, because an install that is insecure until
+somebody reads the documentation is insecure. The way out is
+`ROMARR_AUTH=disabled`, for the real case of an install already sitting behind
+an authenticating reverse proxy -- asking that operator to carry a second
+credential past a proxy that already established identity is friction with no
+security gain. It is a setting, never a default, and crucially never something
+a *missing* key degrades into: `test_off_is_only_ever_explicit` fails if that
+ever changes.
+
+Three ways to present a credential, because the senders differ:
+
+  * `X-Api-Key`, which is what the other *arrs use and what a script will send.
+  * `Authorization: Bearer`, for anything speaking generic HTTP.
+  * `?apikey=`, for senders that cannot set a header at all. A request
+    front-end posting a notification is the case that forces this, and the
+    alternative was leaving the one endpoint that queues downloads open.
+
+A browser gets a signed session cookie instead, so the key is presented once
+rather than sitting in every request and in the page.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+import time
+
+log = logging.getLogger(__name__)
+
+#: Cookie a browser session lives in.
+SESSION_COOKIE = "romarr_session"
+
+#: How long a browser session lasts before the operator logs in again.
+SESSION_SECONDS = 14 * 24 * 3600
+
+#: `ROMARR_AUTH` set to this, and only this, turns the gate off.
+DISABLED = "disabled"
+
+#: scrypt parameters. Deliberately not a bare hash: a ROMarr password is
+#: chosen by a person and will be short, so the cost has to come from the
+#: derivation rather than from the input.
+_SCRYPT_N, _SCRYPT_R, _SCRYPT_P = 2 ** 14, 8, 1
+
+
+def new_api_key() -> str:
+    """A key worth generating. 32 hex characters, from the CSPRNG."""
+    return secrets.token_hex(16)
+
+
+class Auth:
+    """The gate. Holds no state a request can change."""
+
+    def __init__(self, api_key: str = "", password_hash: str = "",
+                 enabled: bool = True,
+                 session_seconds: int = SESSION_SECONDS):
+        self.api_key = api_key or ""
+        self.password_hash = password_hash or ""
+        self.enabled = enabled
+        self.session_seconds = session_seconds
+
+    # -- credentials --------------------------------------------------------
+
+    def check_key(self, presented: str | None) -> bool:
+        """Whether `presented` is the configured key.
+
+        The emptiness check is load-bearing and is not a shortcut for speed:
+        `hmac.compare_digest("", "")` is True, so an install whose key went
+        missing would authorise every request that sent no key at all. That is
+        an outage that fails open, which is the worst way for one to fail.
+        """
+        if not self.api_key or not presented:
+            return False
+        return hmac.compare_digest(str(presented), self.api_key)
+
+    def hash_password(self, password: str) -> str:
+        """`scrypt$<salt>$<digest>`, salted per call."""
+        salt = secrets.token_bytes(16)
+        digest = hashlib.scrypt(password.encode(), salt=salt,
+                                n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P)
+        return (f"scrypt${base64.b64encode(salt).decode()}"
+                f"${base64.b64encode(digest).decode()}")
+
+    def check_password(self, password: str | None) -> bool:
+        """Whether `password` matches the stored hash.
+
+        No password configured means password login is *off*, not open.
+        """
+        if not self.password_hash or not password:
+            return False
+        try:
+            kind, salt_b64, digest_b64 = self.password_hash.split("$", 2)
+            if kind != "scrypt":
+                return False
+            salt = base64.b64decode(salt_b64)
+            expected = base64.b64decode(digest_b64)
+        except Exception:
+            log.warning("stored password hash is unreadable; refusing login")
+            return False
+        got = hashlib.scrypt(password.encode(), salt=salt,
+                             n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P)
+        return hmac.compare_digest(got, expected)
+
+    # -- sessions -----------------------------------------------------------
+
+    def issue_session(self) -> str:
+        """A signed `<expiry>.<signature>` token.
+
+        Signed with the API key, so a session cannot be carried to another
+        install and a rotated key invalidates every outstanding session --
+        which is what rotating a key is for.
+        """
+        expires = int(time.time()) + self.session_seconds
+        body = base64.urlsafe_b64encode(
+            json.dumps({"exp": expires}).encode()).decode().rstrip("=")
+        return f"{body}.{self._sign(body)}"
+
+    def check_session(self, token: str | None) -> bool:
+        if not token or not self.api_key or "." not in token:
+            return False
+        body, _, signature = token.rpartition(".")
+        if not hmac.compare_digest(signature, self._sign(body)):
+            return False
+        try:
+            padding = "=" * (-len(body) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(body + padding))
+            return int(claims["exp"]) > time.time()
+        except Exception:
+            return False
+
+    def _sign(self, body: str) -> str:
+        return hmac.new(self.api_key.encode(), body.encode(),
+                        hashlib.sha256).hexdigest()
+
+    # -- the actual question a request asks ---------------------------------
+
+    def authorised(self, headers, query, cookies) -> bool:
+        """Whether this request may proceed.
+
+        `headers` is anything with case-insensitive `.get`, or a plain dict --
+        both appear, because the server hands over `http.client.HTTPMessage`
+        and the tests hand over a dict.
+        """
+        if not self.enabled:
+            return True
+        presented = (_header(headers, "X-Api-Key")
+                     or _bearer(_header(headers, "Authorization"))
+                     or _first(query.get("apikey")))
+        if self.check_key(presented):
+            return True
+        return self.check_session(cookies.get(SESSION_COOKIE))
+
+
+def _header(headers, name: str) -> str:
+    """One header, case-insensitively, from a dict or an HTTPMessage."""
+    if headers is None:
+        return ""
+    got = headers.get(name)
+    if got:
+        return str(got)
+    lowered = name.lower()
+    for key, value in getattr(headers, "items", lambda: [])():
+        if str(key).lower() == lowered and value:
+            return str(value)
+    return ""
+
+
+def _bearer(value: str) -> str:
+    parts = str(value or "").split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+    return ""
+
+
+def _first(values) -> str:
+    if isinstance(values, (list, tuple)):
+        return str(values[0]) if values else ""
+    return str(values or "")
+
+
+def parse_cookies(raw: str) -> dict[str, str]:
+    """`a=1; b=2` into a dict, tolerating whatever a browser actually sends."""
+    out: dict[str, str] = {}
+    for part in str(raw or "").split(";"):
+        name, sep, value = part.strip().partition("=")
+        if sep and name:
+            out[name] = value
+    return out

--- a/romarr/catalogue.py
+++ b/romarr/catalogue.py
@@ -1,0 +1,234 @@
+"""Finding a plugin, installing your own, and getting one featured.
+
+ROM Hub already installs plugins by slug from a catalogue. Three things were
+missing, and they are the three things that make a catalogue a catalogue
+rather than a list:
+
+  * **search**, because a list you have to read end to end stops working at
+    about thirty entries;
+  * **install your own**, because the interesting plugin is usually the one
+    you just wrote and it is not in anybody's catalogue yet;
+  * **submit**, because the way a plugin gets into the catalogue should not be
+    "know which repository to open a pull request against".
+
+Submission prepares, and never sends. ROMarr builds the entry, validates it,
+and hands back a prefilled link the operator clicks -- publishing something
+under somebody's name is their decision, and a tool that posts on their behalf
+because they clicked "submit" in a settings page has made it for them. It also
+means the flow works with no token configured, which is the normal case.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.parse
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+#: Where a featured submission goes.
+CATALOGUE_REPO = "BlizzHacker/rom-hub"
+
+#: A plugin slug: lower-case, hyphenated, no surprises. This is used as a
+#: directory name and a CLI argument, so it is validated rather than trusted.
+SLUG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+#: Only these hosts may be installed from directly.
+#:
+#: A plugin is code that ROMarr will execute. "Install from any URL" is a
+#: remote code execution feature with a text box, so the source has to be
+#: somewhere the operator can read the code first and somewhere a takedown is
+#: possible. Self-hosted forges are common in this crowd, so the list is
+#: configurable -- but it is a list, never "anything".
+DEFAULT_ALLOWED_HOSTS = ("github.com", "gitlab.com", "codeberg.org",
+                         "git.sr.ht", "bitbucket.org")
+
+
+def search(items: list[dict], query: str = "", *, capability: str = "",
+           platform: str = "", installed: bool | None = None) -> list[dict]:
+    """Filter and rank a catalogue.
+
+    Ranked rather than merely filtered: an exact slug match is what somebody
+    typing `nointro-archive` meant, and burying it under six fuzzy name
+    matches makes the search feel broken even though it worked.
+    """
+    text = str(query or "").strip().lower()
+    wanted_capability = str(capability or "").strip().lower()
+    wanted_platform = str(platform or "").strip().lower()
+
+    scored = []
+    for item in items:
+        if installed is not None and bool(item.get("installed")) != installed:
+            continue
+        capabilities = [str(c).lower() for c in item.get("capabilities") or []]
+        if wanted_capability and wanted_capability not in capabilities:
+            continue
+        platforms = [str(p).lower() for p in item.get("platforms") or []]
+        if wanted_platform and wanted_platform not in platforms:
+            continue
+
+        if not text:
+            scored.append((0, item))
+            continue
+
+        slug = str(item.get("slug") or "").lower()
+        name = str(item.get("name") or "").lower()
+        description = str(item.get("description") or "").lower()
+        author = str(item.get("author") or "").lower()
+
+        if slug == text:
+            rank = 0
+        elif text in slug:
+            rank = 1
+        elif text in name:
+            rank = 2
+        elif text in author:
+            rank = 3
+        elif text in description:
+            rank = 4
+        else:
+            continue
+        scored.append((rank, item))
+
+    scored.sort(key=lambda pair: (pair[0], str(pair[1].get("slug") or "")))
+    return [item for _, item in scored]
+
+
+def facets(items: list[dict]) -> dict:
+    """The capabilities and platforms present, for filter menus.
+
+    Built from what is actually in the catalogue rather than a hardcoded list,
+    so a new capability appears in the UI the moment a plugin declares one.
+    """
+    capabilities: dict[str, int] = {}
+    platforms: dict[str, int] = {}
+    for item in items:
+        for capability in item.get("capabilities") or []:
+            capabilities[str(capability)] = capabilities.get(str(capability), 0) + 1
+        for platform in item.get("platforms") or []:
+            platforms[str(platform)] = platforms.get(str(platform), 0) + 1
+    return {
+        "capabilities": sorted(capabilities.items()),
+        "platforms": sorted(platforms.items()),
+    }
+
+
+@dataclass
+class SourceCheck:
+    ok: bool
+    url: str = ""
+    host: str = ""
+    reason: str = ""
+
+
+def check_source(url: str, allowed_hosts=None) -> SourceCheck:
+    """Whether a repository URL may be installed from.
+
+    A plugin is code ROMarr executes in a subprocess. "Install from any URL"
+    is remote code execution with a text box in front of it, so this refuses
+    anything that is not https on a known forge -- somewhere the operator can
+    read the source first and somewhere a takedown is possible.
+    """
+    raw = str(url or "").strip()
+    if not raw:
+        return SourceCheck(False, reason="no URL given")
+    parts = urllib.parse.urlsplit(raw)
+    if parts.scheme != "https":
+        # Not pedantry: http means anybody on the path chooses what code runs.
+        return SourceCheck(False, url=raw,
+                           reason="must be https -- plain http lets anyone on "
+                                  "the network choose what code you run")
+    host = (parts.hostname or "").lower()
+    if not host:
+        return SourceCheck(False, url=raw, reason="no host in the URL")
+    allowed = [h.lower() for h in (allowed_hosts or DEFAULT_ALLOWED_HOSTS)]
+    if host not in allowed:
+        return SourceCheck(
+            False, url=raw, host=host,
+            reason=f"{host} is not an allowed source. Allowed: "
+                   f"{', '.join(allowed)}. Add it under Settings if you host "
+                   "your own forge.")
+    if not parts.path.strip("/"):
+        return SourceCheck(False, url=raw, host=host,
+                           reason="that is a host, not a repository")
+    return SourceCheck(True, url=raw, host=host)
+
+
+@dataclass
+class Submission:
+    """A catalogue entry somebody wants featured."""
+
+    slug: str = ""
+    name: str = ""
+    repository: str = ""
+    author: str = ""
+    description: str = ""
+    capabilities: list[str] = field(default_factory=list)
+    platforms: list[str] = field(default_factory=list)
+
+    def problems(self, allowed_hosts=None) -> list[str]:
+        """Everything wrong with this, all at once.
+
+        All of them rather than the first: a form that reveals one error per
+        submission takes five round trips to fill in, and each of those is a
+        chance to give up.
+        """
+        out = []
+        if not SLUG.match(self.slug or ""):
+            out.append("slug must be lower-case words joined by hyphens, "
+                       "e.g. my-plugin")
+        if not (self.name or "").strip():
+            out.append("name is required")
+        if not (self.description or "").strip():
+            out.append("description is required -- it is what somebody reads "
+                       "before deciding to run your code")
+        source = check_source(self.repository, allowed_hosts)
+        if not source.ok:
+            out.append(f"repository: {source.reason}")
+        if not self.capabilities:
+            out.append("declare at least one capability, or nothing will ever "
+                       "call the plugin")
+        return out
+
+    def as_entry(self) -> dict:
+        return {
+            "slug": self.slug,
+            "name": self.name,
+            "author": self.author,
+            "repository": self.repository,
+            "description": self.description,
+            "capabilities": list(self.capabilities),
+            "platforms": list(self.platforms),
+        }
+
+
+def submission_link(submission: Submission, repo: str = CATALOGUE_REPO) -> str:
+    """A prefilled issue URL for the operator to click.
+
+    ROMarr does not post it. Publishing something under somebody's name is
+    their decision, and a tool that submits on their behalf because they
+    clicked a button in a settings page has made that decision for them. It
+    also means this works with no token configured, which is the normal case.
+    """
+    body = "\n".join([
+        "Proposed catalogue entry:", "",
+        "```json",
+        _pretty_entry(submission.as_entry()),
+        "```", "",
+        f"Repository: {submission.repository}",
+        "",
+        "_Prepared by ROMarr._",
+    ])
+    query = urllib.parse.urlencode({
+        "title": f"Add plugin: {submission.slug}",
+        "body": body,
+        "labels": "plugin-submission",
+    })
+    return f"https://github.com/{repo}/issues/new?{query}"
+
+
+def _pretty_entry(entry: dict) -> str:
+    import json
+
+    return json.dumps(entry, indent=2)

--- a/romarr/dat.py
+++ b/romarr/dat.py
@@ -1,0 +1,345 @@
+"""Proving an import is the right file.
+
+**This is the thing no other *arr can do.** Radarr cannot tell you whether the
+file it imported is correct, because there is no canonical hash for a movie --
+its last mile is "something arrived, it is probably fine". Every game manager
+that scores filenames is making the same guess with a better vocabulary.
+
+ROMs are the exception. No-Intro and Redump publish the CRC32, MD5 and SHA1 of
+every correct dump in existence, in the Logiqx DAT format, so "is this the
+right file" has an actual answer. That answer is worth more than any amount of
+title parsing: a release can be named perfectly and still be a bad dump, and a
+release named badly can be byte-for-byte correct.
+
+Three distinctions this module refuses to blur:
+
+  * **Verified** -- the hash is in a DAT. The file is the published dump.
+  * **Bad dump** -- a file the exact size of a known ROM whose hash does not
+    match. Corrupt, patched, or tampered with. This is the case worth catching.
+  * **Unknown** -- no hash matched anything. NOT a bad dump: homebrew,
+    translations, new releases and an out-of-date DAT all land here, and
+    treating absence as proof of badness would reject good files with total
+    confidence.
+
+The copier-header trap is the reason naive implementations of this match
+nothing at all. See `header_bytes`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import zlib
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+VERIFIED = "verified"
+BAD_DUMP = "bad-dump"
+UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Rom:
+    """One file inside a DAT entry.
+
+    A cartridge game has one. A Redump disc entry has one per track plus the
+    cue sheet, which is why verifying a disc means verifying a set rather than
+    a file -- and why `selection.pick_rom_set` exists upstream of this.
+    """
+
+    name: str
+    size: int = 0
+    crc: str = ""
+    md5: str = ""
+    sha1: str = ""
+
+
+@dataclass(frozen=True)
+class Game:
+    name: str
+    roms: tuple[Rom, ...] = ()
+    #: No-Intro marks regional variants as clones of a parent entry. This is
+    #: what makes 1G1R possible at all.
+    cloneof: str = ""
+
+
+@dataclass(frozen=True)
+class Match:
+    status: str
+    game: str = ""
+    rom: Rom | None = None
+    dat: str = ""
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == VERIFIED
+
+    def __str__(self) -> str:
+        if self.status == VERIFIED:
+            return f"verified: {self.game} ({self.dat})"
+        if self.status == BAD_DUMP:
+            return f"bad dump: {self.detail}"
+        return "not in any loaded DAT"
+
+
+#: Fixed-size headers that some dumps carry and DATs never include.
+#:
+#: **The single reason a naive implementation matches nothing.** No-Intro
+#: hashes the cartridge contents; a copier or emulator header is metadata
+#: added afterwards. Hash the file as it sits on disk and you get a checksum
+#: that appears in no DAT ever published -- so every NES and SNES import comes
+#: back "unknown" and the feature looks useless rather than broken.
+_FIXED_HEADERS = {
+    ".nes": 16,     # iNES
+    ".fds": 16,     # fwNES
+    ".lnx": 64,     # Lynx
+    ".a78": 128,    # Atari 7800
+}
+
+#: A Super Nintendo dump may or may not carry a 512-byte copier header, and
+#: the extension does not say. The rule the preservation world uses is
+#: arithmetic rather than magic bytes: cartridge data is a whole number of
+#: 32KB banks, so a file 512 bytes over a multiple of 32768 is headered.
+_SMC_SUFFIXES = (".smc", ".sfc", ".swc", ".fig")
+_SMC_HEADER = 512
+_SMC_BANK = 32768
+
+
+def header_size(suffix: str, length: int) -> int:
+    """How many leading bytes to skip, given only the file's length.
+
+    Length rather than contents, because the SMC rule is arithmetic and the
+    caller may be looking at a four-gigabyte disc image it must not read into
+    memory to answer this.
+    """
+    suffix = str(suffix or "").lower()
+    fixed = _FIXED_HEADERS.get(suffix)
+    if fixed and length > fixed:
+        return fixed
+    if suffix in _SMC_SUFFIXES and length % _SMC_BANK == _SMC_HEADER:
+        return _SMC_HEADER
+    return 0
+
+
+def header_bytes(suffix: str, data: bytes) -> int:
+    """How many leading bytes to skip before hashing `data`."""
+    return header_size(suffix, len(data))
+
+
+def hash_bytes(data: bytes, *, suffix: str = "") -> dict:
+    """Every hash a DAT might publish, computed over the ROM proper.
+
+    Returns a dict shaped for `lookup(**hashes)`, so a caller never has to
+    know which algorithms a given DAT happens to carry.
+    """
+    start = header_bytes(suffix, data)
+    body = data[start:] if start else data
+    return {
+        "size": len(body),
+        "crc": f"{zlib.crc32(body) & 0xFFFFFFFF:08x}",
+        "md5": hashlib.md5(body, usedforsecurity=False).hexdigest(),
+        "sha1": hashlib.sha1(body, usedforsecurity=False).hexdigest(),
+    }
+
+
+def hash_file(path, *, chunk: int = 1024 * 1024) -> dict:
+    """`hash_bytes` for a file on disk, read in chunks.
+
+    A PS2 image is several gigabytes and holding one in memory to checksum it
+    would put an import at the mercy of however much RAM the container was
+    given. Only the header -- at most 512 bytes -- is ever buffered.
+    """
+    from pathlib import Path
+
+    path = Path(path)
+    # From the length, never from the contents. Building a buffer the size of
+    # the file to decide whether it has a 512-byte header would allocate four
+    # gigabytes for a PS2 image -- exactly the thing chunked hashing exists to
+    # avoid, reintroduced one line above it.
+    start = header_size(path.suffix, path.stat().st_size)
+    crc = 0
+    md5 = hashlib.md5(usedforsecurity=False)
+    sha1 = hashlib.sha1(usedforsecurity=False)
+    size = 0
+    with open(path, "rb") as handle:
+        if start:
+            handle.seek(start)
+        while True:
+            block = handle.read(chunk)
+            if not block:
+                break
+            crc = zlib.crc32(block, crc)
+            md5.update(block)
+            sha1.update(block)
+            size += len(block)
+    return {"size": size, "crc": f"{crc & 0xFFFFFFFF:08x}",
+            "md5": md5.hexdigest(), "sha1": sha1.hexdigest()}
+
+
+@dataclass
+class Dat:
+    """One parsed DAT -- normally one system."""
+
+    name: str = ""
+    version: str = ""
+    games: dict[str, Game] = field(default_factory=dict)
+    _by_crc: dict[tuple[str, int], tuple[str, Rom]] = field(default_factory=dict)
+    _by_sha1: dict[str, tuple[str, Rom]] = field(default_factory=dict)
+    _by_md5: dict[str, tuple[str, Rom]] = field(default_factory=dict)
+    _sizes: dict[int, str] = field(default_factory=dict)
+
+    def lookup(self, *, crc: str = "", md5: str = "", sha1: str = "",
+               size: int = 0) -> Match:
+        """What this file is, by hash.
+
+        Strongest hash first. CRC32 is 32 bits and collides -- with several
+        million entries across a full DAT collection that stops being
+        theoretical -- so where the DAT published a SHA1 and the caller
+        computed one, that is the answer and CRC is not consulted.
+        """
+        for key, table in ((sha1, self._by_sha1), (md5, self._by_md5)):
+            hit = table.get(str(key or "").lower())
+            if hit:
+                return Match(VERIFIED, hit[0], hit[1], self.name)
+
+        crc = str(crc or "").lower()
+        if crc:
+            hit = self._by_crc.get((crc, int(size or 0)))
+            if hit is None and not size:
+                hit = next((v for (c, _), v in self._by_crc.items() if c == crc),
+                           None)
+            if hit:
+                return Match(VERIFIED, hit[0], hit[1], self.name)
+
+        # Nothing matched. A file the exact size of a known ROM is the case
+        # worth separating out: that is a corrupt or altered copy of something
+        # this DAT knows, not an unrecognised file.
+        if size and int(size) in self._sizes:
+            known = self._sizes[int(size)]
+            return Match(BAD_DUMP, dat=self.name,
+                         detail=f"{size} bytes matches {known!r} but the "
+                                f"checksum does not -- corrupt or altered")
+        return Match(UNKNOWN, dat=self.name)
+
+    def parent_of(self, game: str) -> str:
+        entry = self.games.get(game)
+        if entry is None:
+            return game
+        return entry.cloneof or entry.name
+
+    def one_game_one_rom(self, regions: list[str]) -> dict[str, Game]:
+        """One entry per game, choosing by region preference.
+
+        Igir's headline feature and the reason a 10,000-entry set collapses to
+        a playable 3,000. The ladder is supplied by the caller so that a 1G1R
+        set and a grab of the same title agree about which dump is wanted --
+        `store.settings["preferred_regions"]` feeds both.
+
+        A game whose only dumps fall outside the preference is kept anyway.
+        Dropping it would silently lose titles from a "cleaned" set, which is
+        the kind of loss nobody notices for months.
+        """
+        groups: dict[str, list[Game]] = {}
+        for game in self.games.values():
+            groups.setdefault(self.parent_of(game.name), []).append(game)
+
+        order = [r.lower() for r in regions]
+
+        def rank(game: Game) -> tuple[int, int, str]:
+            found = _regions_in(game.name)
+            best = min((order.index(r) for r in found if r in order),
+                       default=len(order))
+            # Prefer the parent on a tie: No-Intro makes the canonical dump
+            # the parent, so it is the right answer when nothing else decides.
+            return (best, 0 if not game.cloneof else 1, game.name)
+
+        return {min(members, key=rank).name: min(members, key=rank)
+                for members in groups.values()}
+
+
+_REGION_IN_NAME = re.compile(r"\(([^)]*)\)")
+
+
+def _regions_in(name: str) -> set[str]:
+    """Region words from a No-Intro style name: `Game (USA, Europe)`."""
+    out = set()
+    for group in _REGION_IN_NAME.findall(name or ""):
+        for part in group.split(","):
+            out.add(part.strip().lower())
+    return out
+
+
+def parse_dat(body: str) -> Dat:
+    """A Logiqx DAT, as both No-Intro and Redump publish it."""
+    import xml.etree.ElementTree as ET
+
+    dat = Dat()
+    try:
+        root = ET.fromstring(body or "")
+    except ET.ParseError:
+        log.warning("DAT is not valid XML; ignoring it")
+        return dat
+
+    header = root.find("header")
+    if header is not None:
+        dat.name = (header.findtext("name") or "").strip()
+        dat.version = (header.findtext("version") or "").strip()
+
+    for node in root.iter("game"):
+        name = (node.get("name") or "").strip()
+        if not name:
+            continue
+        roms = []
+        for rom_node in node.findall("rom"):
+            rom = Rom(
+                name=(rom_node.get("name") or "").strip(),
+                size=int(rom_node.get("size") or 0),
+                crc=(rom_node.get("crc") or "").strip().lower(),
+                md5=(rom_node.get("md5") or "").strip().lower(),
+                sha1=(rom_node.get("sha1") or "").strip().lower(),
+            )
+            roms.append(rom)
+            if rom.crc:
+                dat._by_crc.setdefault((rom.crc, rom.size), (name, rom))
+            if rom.sha1:
+                dat._by_sha1.setdefault(rom.sha1, (name, rom))
+            if rom.md5:
+                dat._by_md5.setdefault(rom.md5, (name, rom))
+            if rom.size:
+                dat._sizes.setdefault(rom.size, name)
+        dat.games[name] = Game(name=name, roms=tuple(roms),
+                               cloneof=(node.get("cloneof") or "").strip())
+    return dat
+
+
+class DatIndex:
+    """Every loaded DAT, queried as one.
+
+    An operator has one DAT per system and a file arriving from a download does
+    not announce which system it belongs to -- so verification asks all of
+    them. An index with nothing in it answers `unknown`, because day one is the
+    common case and it must not turn every import into an error.
+    """
+
+    def __init__(self):
+        self.dats: list[Dat] = []
+
+    def add(self, dat: Dat) -> None:
+        if dat.games:
+            self.dats.append(dat)
+
+    def lookup(self, **hashes) -> Match:
+        best = Match(UNKNOWN)
+        for dat in self.dats:
+            got = dat.lookup(**hashes)
+            if got.status == VERIFIED:
+                return got
+            # A bad-dump verdict from one DAT is only interesting if no other
+            # DAT verifies the file -- size collisions across systems are
+            # ordinary, so this is held back rather than returned early.
+            if got.status == BAD_DUMP and best.status == UNKNOWN:
+                best = got
+        return best

--- a/romarr/downloaders.py
+++ b/romarr/downloaders.py
@@ -25,6 +25,7 @@ this once did, does not protect anything: it just means usenet never works.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 
@@ -178,6 +179,178 @@ class NZBGet:
         return out
 
 
+@dataclass
+class TransmissionConfig:
+    base_url: str
+    username: str = ""
+    password: str = ""
+    category: str = "romarr"
+    timeout: int = 30
+
+
+class Transmission:
+    """Transmission's RPC, and the 409 handshake everybody hits first.
+
+    Every RPC call from a client with no session id is answered **409** with
+    an `X-Transmission-Session-Id` header, and the call has to be repeated
+    carrying it. That is not an error condition, it is the protocol. A client
+    that treats 409 as a failure never adds a single torrent and reports the
+    daemon as broken -- which is exactly what it looks like from outside.
+
+    The id is kept and reused: re-challenging on every call doubles every
+    request for nothing.
+    """
+
+    protocol = "torrent"
+    RPC_PATH = "/transmission/rpc"
+    SESSION_HEADER = "X-Transmission-Session-Id"
+
+    def __init__(self, config, session=None):
+        self._config = config
+        self._session = session or requests.Session()
+        self._session_id = ""
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._config.base_url)
+
+    def _call(self, method: str, arguments: dict) -> dict:
+        url = self._config.base_url.rstrip("/") + self.RPC_PATH
+        payload = json.dumps({"method": method, "arguments": arguments})
+        auth = ((self._config.username, self._config.password)
+                if self._config.username else None)
+        for attempt in range(2):
+            headers = {"Content-Type": "application/json"}
+            if self._session_id:
+                headers[self.SESSION_HEADER] = self._session_id
+            response = self._session.post(
+                url, data=payload, headers=headers, auth=auth,
+                timeout=self._config.timeout)
+            if getattr(response, "status_code", 200) == 409 and attempt == 0:
+                self._session_id = response.headers.get(self.SESSION_HEADER, "")
+                continue
+            try:
+                return response.json() or {}
+            except Exception:
+                return {}
+        return {}
+
+    def reachable(self) -> bool:
+        try:
+            return bool(self._call("session-get", {}))
+        except Exception as exc:
+            log.warning("Transmission unreachable: %s", exc)
+            return False
+
+    def add(self, magnet_or_url: str, *, save_path: str | None = None) -> bool:
+        arguments = {"filename": magnet_or_url}
+        if save_path:
+            arguments["download-dir"] = save_path
+        if self._config.category:
+            arguments["labels"] = [self._config.category]
+        try:
+            body = self._call("torrent-add", arguments)
+        except Exception as exc:
+            log.warning("Transmission add failed: %s", exc)
+            return False
+        # Transmission answers HTTP 200 with {"result": "<error text>"} when
+        # it refuses, so reading the status code alone calls every rejection a
+        # success. "torrent-duplicate" in the arguments means it is already
+        # there, which is the outcome the caller wanted.
+        if body.get("result") != "success":
+            log.warning("Transmission refused the torrent: %s", body.get("result"))
+            return False
+        return True
+
+
+@dataclass
+class DelugeConfig:
+    base_url: str
+    password: str = ""
+    category: str = "romarr"
+    timeout: int = 30
+
+
+class Deluge:
+    """Deluge's WebUI JSON-RPC, with both of its traps handled.
+
+    **It refuses everything until `auth.login` succeeds**, and answers an
+    unauthenticated call with an ordinary-looking JSON error rather than a
+    401 -- so a client that does not log in looks like one talking to a broken
+    daemon.
+
+    **The WebUI is a separate process from the daemon.** A freshly started
+    WebUI is attached to nothing: `auth.login` succeeds, every later call
+    returns cheerfully, and no torrent appears anywhere. `web.connect` against
+    the first known host is what attaches it.
+    """
+
+    protocol = "torrent"
+    RPC_PATH = "/json"
+
+    def __init__(self, config, session=None):
+        self._config = config
+        self._session = session or requests.Session()
+        self._id = 0
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._config.base_url)
+
+    def _call(self, method: str, params: list) -> dict:
+        self._id += 1
+        url = self._config.base_url.rstrip("/") + self.RPC_PATH
+        response = self._session.post(
+            url,
+            data=json.dumps({"method": method, "params": params, "id": self._id}),
+            headers={"Content-Type": "application/json"},
+            timeout=self._config.timeout)
+        try:
+            return response.json() or {}
+        except Exception:
+            return {}
+
+    def _ready(self) -> bool:
+        if not self._call("auth.login", [self._config.password]).get("result"):
+            log.warning("Deluge rejected the WebUI password")
+            return False
+        if self._call("web.connected", []).get("result"):
+            return True
+        hosts = self._call("web.get_hosts", []).get("result") or []
+        if not hosts:
+            log.warning("Deluge WebUI is not attached to a daemon and knows "
+                        "no hosts to attach to")
+            return False
+        return bool(self._call("web.connect", [hosts[0][0]]).get("result", True))
+
+    def reachable(self) -> bool:
+        try:
+            return self._ready()
+        except Exception as exc:
+            log.warning("Deluge unreachable: %s", exc)
+            return False
+
+    def add(self, magnet_or_url: str, *, save_path: str | None = None) -> bool:
+        try:
+            if not self._ready():
+                return False
+            options = {"download_location": save_path} if save_path else {}
+            body = self._call("core.add_torrent_magnet", [magnet_or_url, options])
+            if body.get("error") or not body.get("result"):
+                log.warning("Deluge refused the torrent: %s", body.get("error"))
+                return False
+            if self._config.category:
+                # Best effort: the Label plugin may not be enabled, and a
+                # missing label is no reason to call a successful add a
+                # failure.
+                self._call("label.set_torrent",
+                           [body.get("result"), self._config.category])
+            return True
+        except Exception as exc:
+            log.warning("Deluge add failed: %s", exc)
+            return False
+
+
 def pick_client(protocol: str, clients: list) -> object | None:
     """The first configured, reachable client that speaks this protocol.
 
@@ -226,6 +399,27 @@ CLIENT_TYPES = {
             FIELD("username", "Username"),
             FIELD("password", "Password", "secret"),
             FIELD("category", "Category", default="romarr"),
+        ],
+    },
+    "transmission": {
+        "label": "Transmission",
+        "protocol": "torrent",
+        "default_port": 9091,
+        "fields": _COMMON + [
+            FIELD("username", "Username"),
+            FIELD("password", "Password", "secret"),
+            FIELD("category", "Label", default="romarr"),
+        ],
+    },
+    "deluge": {
+        "label": "Deluge",
+        "protocol": "torrent",
+        "default_port": 8112,
+        "fields": _COMMON + [
+            FIELD("password", "WebUI Password", "secret",
+                  help="The WebUI password, not the daemon's. Default: deluge"),
+            FIELD("category", "Label", default="romarr",
+                  help="Needs the Label plugin; ignored when it is not enabled"),
         ],
     },
     "sabnzbd": {
@@ -286,6 +480,13 @@ def build_client(cfg: dict):
         client = QBittorrent(QbitConfig(
             base_url=url, username=cfg.get("username", ""),
             password=cfg.get("password", ""), category=category))
+    elif kind == "transmission":
+        client = Transmission(TransmissionConfig(
+            base_url=url, username=cfg.get("username", ""),
+            password=cfg.get("password", ""), category=category))
+    elif kind == "deluge":
+        client = Deluge(DelugeConfig(
+            base_url=url, password=cfg.get("password", ""), category=category))
     elif kind == "sabnzbd":
         client = SABnzbd(SabConfig(
             base_url=url, api_key=cfg.get("api_key", ""), category=category))
@@ -305,8 +506,8 @@ def build_client(cfg: dict):
 
 def redact(cfg: dict) -> dict:
     """A client configuration safe to send to a browser."""
-    spec = CLIENT_TYPES.get(str(cfg.get("type") or "").lower(), {})
-    secrets = {f["name"] for f in spec.get("fields", []) if f["type"] == "secret"}
+    secrets = {f["name"] for spec in CLIENT_TYPES.values()
+               for f in spec.get("fields", []) if f["type"] == "secret"}
     return {
         k: (SECRET_PLACEHOLDER if k in secrets and v else v)
         for k, v in cfg.items()

--- a/romarr/frontends.py
+++ b/romarr/frontends.py
@@ -1,0 +1,229 @@
+"""Handing the library to the launchers people actually sit in front of.
+
+LaunchBox, Playnite and ES-DE are where a lot of people play. None of them
+speaks a common protocol, and two of the three are Windows .NET applications
+whose plugin model is a compiled DLL -- so the durable integration is not a
+plugin at all, it is emitting the formats they already read.
+
+That distinction matters. A plugin breaks when the host application changes
+its API; a `gamelist.xml` has been read the same way for fifteen years. The
+plugins in `contrib/` are a convenience on top of this module, not a
+replacement for it -- and if one of them ever stops working, the export is
+still there.
+
+Everything here is a pure function from library rows to text, so all of it is
+tested. The plugins are not, because .NET cannot be compiled in this
+environment, and that difference is stated in `contrib/README.md` rather than
+glossed over.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+log = logging.getLogger(__name__)
+
+#: ROMarr slug -> the platform name each launcher expects.
+#:
+#: These are not decoration. LaunchBox and Playnite match their metadata by
+#: platform *name*, so a game filed under a name they do not recognise imports
+#: with no box art, no description and no association with the rest of that
+#: system's library -- it looks like the export half-worked, which is harder to
+#: diagnose than a clean failure.
+LAUNCHBOX_PLATFORMS = {
+    "nes": "Nintendo Entertainment System",
+    "famicom": "Nintendo Famicom",
+    "fds": "Nintendo Famicom Disk System",
+    "snes": "Super Nintendo Entertainment System",
+    "sfam": "Super Famicom",
+    "n64": "Nintendo 64",
+    "gb": "Nintendo Game Boy",
+    "gbc": "Nintendo Game Boy Color",
+    "gba": "Nintendo Game Boy Advance",
+    "nds": "Nintendo DS",
+    "3ds": "Nintendo 3DS",
+    "ngc": "Nintendo GameCube",
+    "wii": "Nintendo Wii",
+    "genesis-slash-megadrive": "Sega Genesis",
+    "sms": "Sega Master System",
+    "gamegear": "Sega Game Gear",
+    "sega32": "Sega 32X",
+    "segacd": "Sega CD",
+    "saturn": "Sega Saturn",
+    "dc": "Sega Dreamcast",
+    "psx": "Sony Playstation",
+    "ps2": "Sony Playstation 2",
+    "psp": "Sony PSP",
+    "atari2600": "Atari 2600",
+    "atari5200": "Atari 5200",
+    "atari7800": "Atari 7800",
+    "lynx": "Atari Lynx",
+    "jaguar": "Atari Jaguar",
+    "atari-jaguar-cd": "Atari Jaguar CD",
+    "3do": "3DO Interactive Multiplayer",
+    "colecovision": "ColecoVision",
+    "intellivision": "Mattel Intellivision",
+    "vectrex": "GCE Vectrex",
+    "turbografx16--1": "NEC TurboGrafx-16",
+    "turbografx-16-slash-pc-engine-cd": "NEC TurboGrafx-CD",
+    "supergrafx": "NEC SuperGrafx",
+    "pc-fx": "NEC PC-FX",
+    "wonderswan": "WonderSwan",
+    "wonderswan-color": "WonderSwan Color",
+    "neo-geo-pocket": "SNK Neo Geo Pocket",
+    "neo-geo-pocket-color": "SNK Neo Geo Pocket Color",
+    "neogeoaes": "SNK Neo Geo AES",
+    "neogeomvs": "SNK Neo Geo MVS",
+    "neo-geo-cd": "SNK Neo Geo CD",
+    "virtualboy": "Nintendo Virtual Boy",
+    "amiga": "Commodore Amiga",
+    "amiga-cd32": "Commodore Amiga CD32",
+    "c64": "Commodore 64",
+    "c128": "Commodore 128",
+    "vic-20": "Commodore VIC-20",
+    "acpc": "Amstrad CPC",
+    "zxs": "Sinclair ZX Spectrum",
+    "msx": "Microsoft MSX",
+    "msx2": "Microsoft MSX2",
+    "sharp-x68000": "Sharp X68000",
+    "dos": "MS-DOS",
+    "arcade": "Arcade",
+    "philips-cd-i": "Philips CD-i",
+}
+
+#: ES-DE reads a directory per system, named by its own short slug.
+ESDE_FOLDERS = {
+    "genesis-slash-megadrive": "megadrive",
+    "turbografx16--1": "tg16",
+    "turbografx-16-slash-pc-engine-cd": "pcenginecd",
+    "neo-geo-pocket": "ngp",
+    "neo-geo-pocket-color": "ngpc",
+    "neogeoaes": "neogeo",
+    "neogeomvs": "neogeo",
+    "neo-geo-cd": "neogeocd",
+    "atari-jaguar-cd": "atarijaguarcd",
+    "jaguar": "atarijaguar",
+    "philips-cd-i": "cdimono1",
+    "sharp-x68000": "x68000",
+    "vic-20": "vic20",
+    "3do": "3do",
+    "sfam": "snes",
+    "famicom": "nes",
+}
+
+
+def launchbox_platform(slug: str) -> str:
+    """LaunchBox's name for a platform, or the slug when it has none."""
+    return LAUNCHBOX_PLATFORMS.get(str(slug or "").lower(), str(slug or ""))
+
+
+def esde_folder(slug: str) -> str:
+    return ESDE_FOLDERS.get(str(slug or "").lower(), str(slug or ""))
+
+
+def _pretty(root: ET.Element) -> str:
+    raw = ET.tostring(root, encoding="utf-8")
+    return minidom.parseString(raw).toprettyxml(indent="  ", encoding="utf-8") \
+        .decode("utf-8")
+
+
+def to_launchbox(rows: list[dict]) -> str:
+    """A LaunchBox platform XML.
+
+    LaunchBox stores one file per platform under `Data/Platforms/`, and its
+    importer reads the same shape. `ApplicationPath` is what it launches, so a
+    row with no path is skipped rather than written as an entry that cannot
+    start -- a dead tile is worse than a missing one, because it looks like a
+    working library until somebody clicks it.
+    """
+    root = ET.Element("LaunchBox")
+    written = 0
+    for row in rows:
+        path = str(row.get("path") or "").strip()
+        if not path:
+            continue
+        game = ET.SubElement(root, "Game")
+        ET.SubElement(game, "ApplicationPath").text = path
+        ET.SubElement(game, "Title").text = str(row.get("title") or "")
+        ET.SubElement(game, "Platform").text = launchbox_platform(
+            row.get("platform"))
+        ET.SubElement(game, "ID").text = str(row.get("id") or "")
+        if row.get("region"):
+            ET.SubElement(game, "Region").text = str(row["region"])
+        if row.get("notes"):
+            ET.SubElement(game, "Notes").text = str(row["notes"])
+        # ROMarr knows something LaunchBox has no field for: whether the file
+        # verified against a DAT. It goes in Notes rather than being dropped,
+        # because it is the most useful thing in the row.
+        if row.get("verified"):
+            existing = game.find("Notes")
+            note = f"ROMarr: {row['verified']}"
+            if existing is None:
+                ET.SubElement(game, "Notes").text = note
+            else:
+                existing.text = f"{existing.text}\n{note}"
+        written += 1
+    log.info("LaunchBox export: %d of %d rows had a path", written, len(rows))
+    return _pretty(root)
+
+
+def to_gamelist(rows: list[dict]) -> str:
+    """An ES-DE / EmulationStation `gamelist.xml` for ONE system.
+
+    Paths are written relative with a leading `./`, which is what
+    EmulationStation expects and what makes a gamelist survive the ROM
+    directory being mounted somewhere else -- the normal case when the files
+    live on a NAS and the frontend runs on a handheld.
+    """
+    root = ET.Element("gameList")
+    for row in rows:
+        name = str(row.get("filename") or row.get("path") or "").strip()
+        if not name:
+            continue
+        game = ET.SubElement(root, "game")
+        ET.SubElement(game, "path").text = f"./{name.lstrip('./')}"
+        ET.SubElement(game, "name").text = str(row.get("title") or name)
+        if row.get("desc"):
+            ET.SubElement(game, "desc").text = str(row["desc"])
+        if row.get("region"):
+            ET.SubElement(game, "region").text = str(row["region"])
+    return _pretty(root)
+
+
+def to_playnite(rows: list[dict]) -> str:
+    """JSON for the Playnite extension in `contrib/`.
+
+    Deliberately flat and explicit. The consumer is a PowerShell script, and
+    anything that needs a schema to interpret is a script that breaks the
+    first time a field is absent.
+    """
+    return json.dumps({
+        "source": "ROMarr",
+        "version": 1,
+        "games": [
+            {
+                "name": str(row.get("title") or ""),
+                "platform": launchbox_platform(row.get("platform")),
+                "romPath": str(row.get("path") or ""),
+                "id": str(row.get("id") or ""),
+                "verified": str(row.get("verified") or ""),
+            }
+            for row in rows if row.get("path")
+        ],
+    }, indent=2)
+
+
+FORMATS = {
+    "launchbox": {"label": "LaunchBox", "render": to_launchbox,
+                  "content_type": "application/xml; charset=utf-8",
+                  "filename": "LaunchBox.xml"},
+    "gamelist": {"label": "ES-DE / EmulationStation", "render": to_gamelist,
+                 "content_type": "application/xml; charset=utf-8",
+                 "filename": "gamelist.xml"},
+    "playnite": {"label": "Playnite", "render": to_playnite,
+                 "content_type": "application/json; charset=utf-8",
+                 "filename": "romarr-playnite.json"},
+}

--- a/romarr/indexers.py
+++ b/romarr/indexers.py
@@ -392,25 +392,223 @@ class Torznab:
         )
 
 
-def build_indexer(cfg: dict) -> Torznab | None:
+@dataclass
+class TorrentRssConfig:
+    url: str
+    name: str = "Torrent RSS"
+    private: bool = False
+    timeout: int = 60
+
+
+class TorrentRss:
+    """A plain RSS feed of torrents, as Radarr's "Torrent RSS Feed" offers.
+
+    No API, no key, no categories -- which is the whole difficulty. Everything
+    downstream assumes Newznab-shaped metadata, and the two fields a bare feed
+    does not carry are the two that decide whether a release survives:
+
+      * **Category.** `is_game_release` rejects anything without one, so every
+        result from a feed would be discarded before it was ever scored. The
+        feed is a game feed because the operator pointed ROMarr at it; that
+        decision is what the category records.
+      * **Seeders.** A feed does not publish them. Reporting 0 would read as
+        "dead torrent" on a public tracker and be rejected outright, so a feed
+        reports its items as if private -- keep it, rank it low, let the title
+        and size decide.
+
+    `search()` filters client-side. A feed has no query interface at all, so
+    the alternative is handing the scorer the entire feed for every request.
+    """
+
+    def __init__(self, config: TorrentRssConfig,
+                 session: requests.Session | None = None):
+        self._config = config
+        self._session = session or requests.Session()
+
+    @property
+    def name(self) -> str:
+        return self._config.name
+
+    def _body(self) -> str:
+        response = self._session.get(self._config.url,
+                                     timeout=self._config.timeout)
+        response.raise_for_status()
+        return response.text
+
+    def caps(self) -> bool:
+        """A feed that parses to at least a well-formed document is reachable."""
+        self._body()
+        return True
+
+    def search(self, term: str, *, limit: int = 100) -> list[Release]:
+        wanted = [w for w in _normalise_words(term) if len(w) > 2]
+        out = []
+        for release in self.parse(self._body()):
+            haystack = " ".join(_normalise_words(release.title))
+            if all(w in haystack for w in wanted):
+                out.append(release)
+            if len(out) >= limit:
+                break
+        return out
+
+    def parse(self, body: str) -> list[Release]:
+        import xml.etree.ElementTree as ET
+
+        try:
+            root = ET.fromstring(body or "")
+        except ET.ParseError:
+            log.warning("%s returned a feed that is not XML", self.name)
+            return []
+
+        out = []
+        for item in root.iter("item"):
+            title = (item.findtext("title") or "").strip()
+            enclosure = item.find("enclosure")
+            link = ""
+            size = 0
+            if enclosure is not None:
+                link = (enclosure.get("url") or "").strip()
+                try:
+                    size = int(enclosure.get("length") or 0)
+                except ValueError:
+                    size = 0
+            if not link:
+                link = (item.findtext("link") or "").strip()
+            if not title or not link:
+                continue
+            out.append(Release(
+                title=title, size=size,
+                # See the class docstring: a feed publishes no seeder count,
+                # and 0 on a public tracker means "dead".
+                seeders=1,
+                categories=(SEARCH_CATEGORIES[0],),
+                download_url=link, protocol="torrent",
+                indexer=self.name, private=True,
+            ))
+        return out
+
+
+@dataclass
+class TorrentPotatoConfig:
+    url: str
+    name: str = "TorrentPotato"
+    user: str = ""
+    passkey: str = ""
+    private: bool = True
+    timeout: int = 60
+
+
+class TorrentPotato:
+    """The TorrentPotato JSON API, as Radarr offers it.
+
+    A small JSON protocol a handful of private trackers expose directly. Its
+    one trap is `size`, which is **megabytes** -- reading it as bytes turns a
+    3 MB SNES release into 3 bytes, which the scorer rejects as "too small to
+    be a ROM". The indexer would return results, every one would be discarded,
+    and nothing would say why.
+    """
+
+    def __init__(self, config: TorrentPotatoConfig,
+                 session: requests.Session | None = None):
+        self._config = config
+        self._session = session or requests.Session()
+
+    @property
+    def name(self) -> str:
+        return self._config.name
+
+    def _get(self, **params) -> dict:
+        query = urlencode({**params, "user": self._config.user,
+                           "passkey": self._config.passkey})
+        response = self._session.get(
+            f"{self._config.url.rstrip('/')}?{query}",
+            timeout=self._config.timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def caps(self) -> bool:
+        self._get(t="search", q="")
+        return True
+
+    def search(self, term: str, *, limit: int = 100) -> list[Release]:
+        return self.parse(self._get(t="search", q=term))[:limit]
+
+    def parse(self, body) -> list[Release]:
+        rows = (body or {}).get("results") if isinstance(body, dict) else None
+        if not isinstance(rows, list):
+            return []
+        out = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            link = str(row.get("download_url") or "").strip()
+            title = str(row.get("release_name") or "").strip()
+            if not link or not title:
+                continue
+            try:
+                megabytes = float(row.get("size") or 0)
+            except (TypeError, ValueError):
+                megabytes = 0.0
+            out.append(Release(
+                title=title,
+                size=int(megabytes * 1024 * 1024),
+                seeders=int(row.get("seeders") or 0),
+                categories=(SEARCH_CATEGORIES[0],),
+                download_url=link, protocol="torrent",
+                indexer=self.name, private=self._config.private,
+            ))
+        return out
+
+
+def _normalise_words(text: str) -> list[str]:
+    import re
+
+    return re.sub(r"[^a-z0-9]+", " ", str(text or "").lower()).split()
+
+
+def driver_for(kind: str) -> str:
+    """Which client family a stored indexer type belongs to."""
+    return INDEXER_TYPES.get(str(kind or "").lower(), {}).get("driver", "")
+
+
+def build_indexer(cfg: dict):
     """A searchable client for a stored indexer entry, or None.
 
     Prowlarr entries return None: they are driven by the Prowlarr class, which
     the service holds separately because it aggregates many indexers rather
-    than being one.
+    than being one. Searching it here as well would search it twice.
+
+    Everything else is dispatched on the type's declared driver rather than on
+    its name, which is what lets Jackett, NZBHydra2, Cardigann and Bitmagnet be
+    four rows in a table instead of four clients: they are all Torznab or
+    Newznab underneath, and the differences that matter -- default port, URL
+    shape, whether a key is required -- are configuration, not code.
     """
     kind = str(cfg.get("type") or "").lower()
-    if kind not in ("torznab", "newznab"):
+    driver = driver_for(kind)
+    if driver in ("", "prowlarr") or not cfg.get("url"):
         return None
-    if not cfg.get("url"):
-        return None
+    spec = INDEXER_TYPES[kind]
+    name = cfg.get("name") or spec["label"]
+
+    if driver == "rss":
+        return TorrentRss(TorrentRssConfig(
+            url=cfg["url"], name=name,
+            private=bool(cfg.get("private", True))))
+    if driver == "potato":
+        return TorrentPotato(TorrentPotatoConfig(
+            url=cfg["url"], name=name,
+            user=str(cfg.get("user") or ""),
+            passkey=str(cfg.get("passkey") or ""),
+            private=bool(cfg.get("private", True))))
+
     categories = tuple(indexer_categories(cfg)) or SEARCH_CATEGORIES
     return Torznab(TorznabConfig(
         base_url=cfg.get("url", ""),
         api_key=cfg.get("api_key", ""),
-        name=cfg.get("name") or kind.title(),
+        name=name,
         categories=categories,
-        protocol="usenet" if kind == "newznab" else "torrent",
+        protocol=spec["protocol"] if spec["protocol"] != "any" else "torrent",
         private=bool(cfg.get("private", False)),
     ))
 
@@ -466,11 +664,35 @@ _INDEXER_COMMON = [
                   help="Keep low-seeder results and never rebuild a public magnet"),
 ]
 
+def _family(url_default: str, url_help: str, *, key_required: bool = True,
+            private_default: bool = False) -> list[dict]:
+    """The common field list, with the product's own URL default and hint.
+
+    The hint is the point. Every one of these products speaks Torznab or
+    Newznab, so the code is identical -- what differs is the URL an operator
+    has to type, and getting it wrong is by far the most common way one of
+    these ends up configured, tested and returning nothing.
+    """
+    fields = []
+    for field in _INDEXER_COMMON:
+        field = dict(field)
+        if field["name"] == "url":
+            field.update(default=url_default, help=url_help)
+        elif field["name"] == "api_key":
+            field["required"] = key_required
+        elif field["name"] == "private":
+            field["default"] = private_default
+        fields.append(field)
+    return fields
+
+
 INDEXER_TYPES = {
     "prowlarr": {
         "label": "Prowlarr",
         "protocol": "any",
+        "driver": "prowlarr",
         "managed": True,
+        "help": "Aggregates every tracker you configure in it. Recommended.",
         "fields": [
             INDEXER_FIELD("name", "Name", default="Prowlarr"),
             INDEXER_FIELD("enable", "Enable", "bool", True),
@@ -478,8 +700,92 @@ INDEXER_TYPES = {
             INDEXER_FIELD("api_key", "API Key", "secret"),
         ],
     },
-    "torznab": {"label": "Torznab", "protocol": "torrent", "fields": _INDEXER_COMMON},
-    "newznab": {"label": "Newznab", "protocol": "usenet", "fields": _INDEXER_COMMON},
+    # -- aggregators and proxies, all Torznab/Newznab underneath -------------
+    "jackett": {
+        "label": "Jackett",
+        "protocol": "torrent",
+        "driver": "torznab",
+        "help": "The long-standing Prowlarr alternative. Caches queries and "
+                "carries definitions for obscure trackers Prowlarr dropped.",
+        "fields": _family(
+            "http://localhost:9117/api/v2.0/indexers/all/results/torznab/",
+            "Jackett's Torznab endpoint, NOT its homepage. `/indexers/all/` "
+            "searches every tracker at once; swap `all` for a tracker id to "
+            "search just that one."),
+    },
+    "nzbhydra2": {
+        "label": "NZBHydra2",
+        "protocol": "usenet",
+        "driver": "torznab",
+        "help": "Usenet-focused aggregator. Merges and dedupes across several "
+                "Newznab indexers.",
+        "fields": _family(
+            "http://localhost:5076/api",
+            "NZBHydra2's Newznab endpoint. Use /torznab/api instead if you "
+            "want its torrent results."),
+    },
+    "cardigann": {
+        "label": "Cardigann",
+        "protocol": "torrent",
+        "driver": "torznab",
+        "help": "Definition-driven proxy for trackers Jackett and Prowlarr do "
+                "not carry.",
+        "fields": _family(
+            "http://localhost:5060/torznab/",
+            "Cardigann's Torznab endpoint, with the indexer name appended.",
+            private_default=True),
+    },
+    "bitmagnet": {
+        "label": "Bitmagnet",
+        "protocol": "torrent",
+        "driver": "torznab",
+        "help": "Self-hosted DHT crawler. Indexes the network directly, so it "
+                "depends on no third-party tracker at all.",
+        "fields": _family(
+            "http://localhost:3333/torznab",
+            "Bitmagnet's Torznab endpoint.",
+            # It crawls the DHT itself, so there is nobody to authenticate to.
+            # Demanding a key would make a correct setup look broken.
+            key_required=False),
+    },
+    # -- raw protocols -------------------------------------------------------
+    "torznab": {"label": "Torznab", "protocol": "torrent", "driver": "torznab",
+                "help": "Any Torznab-compatible indexer.",
+                "fields": _INDEXER_COMMON},
+    "newznab": {"label": "Newznab", "protocol": "usenet", "driver": "torznab",
+                "help": "Any Newznab-compatible usenet indexer.",
+                "fields": _INDEXER_COMMON},
+    "torrentrss": {
+        "label": "Torrent RSS Feed",
+        "protocol": "torrent",
+        "driver": "rss",
+        "help": "A plain RSS feed of torrents. No query interface, so ROMarr "
+                "filters it here.",
+        "fields": [
+            INDEXER_FIELD("name", "Name", default="Torrent RSS"),
+            INDEXER_FIELD("enable", "Enable", "bool", True),
+            INDEXER_FIELD("url", "Feed URL",
+                          help="The RSS URL, including any passkey it needs"),
+            INDEXER_FIELD("priority", "Priority", "int", 25),
+            INDEXER_FIELD("private", "Private tracker", "bool", True),
+        ],
+    },
+    "torrentpotato": {
+        "label": "TorrentPotato",
+        "protocol": "torrent",
+        "driver": "potato",
+        "help": "The TorrentPotato JSON API, exposed by a few private "
+                "trackers directly.",
+        "fields": [
+            INDEXER_FIELD("name", "Name", default="TorrentPotato"),
+            INDEXER_FIELD("enable", "Enable", "bool", True),
+            INDEXER_FIELD("url", "URL"),
+            INDEXER_FIELD("user", "Username"),
+            INDEXER_FIELD("passkey", "Passkey", "secret"),
+            INDEXER_FIELD("priority", "Priority", "int", 25),
+            INDEXER_FIELD("private", "Private tracker", "bool", True),
+        ],
+    },
 }
 
 
@@ -496,10 +802,24 @@ def indexer_categories(cfg: dict) -> list[int]:
 SECRET_PLACEHOLDER = "********"
 
 
+def secret_field_names() -> set[str]:
+    """Every field name that is a secret in *any* indexer type.
+
+    Deliberately the union rather than the current type's own fields.
+    Redaction used to consult only the configured type, so a key that arrived
+    under one shape and stayed after the type changed -- an operator switching
+    a Torznab entry to a Torrent RSS feed, say -- was no longer a declared
+    field and went to the browser in the clear. The set of names that are
+    *ever* credentials is small and stable; the set a given row happens to
+    carry is neither.
+    """
+    return {f["name"] for spec in INDEXER_TYPES.values()
+            for f in spec.get("fields", []) if f["type"] == "secret"}
+
+
 def redact_indexer(cfg: dict) -> dict:
     """An indexer configuration safe to send to a browser."""
-    spec = INDEXER_TYPES.get(str(cfg.get("type") or "").lower(), {})
-    secrets = {f["name"] for f in spec.get("fields", []) if f["type"] == "secret"}
+    secrets = secret_field_names()
     return {
         k: (SECRET_PLACEHOLDER if k in secrets and v else v)
         for k, v in cfg.items()

--- a/romarr/library.py
+++ b/romarr/library.py
@@ -18,10 +18,11 @@ import os
 import shutil
 import subprocess
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
+from .dat import BAD_DUMP, UNKNOWN, VERIFIED, Match, hash_bytes
 from .platforms import Platform
 from .selection import pick_rom_set
 
@@ -90,6 +91,9 @@ class ImportResult:
     ok: bool
     destination: Path | None
     reason: str = ""
+    #: What the DAT said about the bytes that actually landed. `unknown` when
+    #: no DAT is loaded, which is the default and is not a failure.
+    verification: Match = field(default_factory=lambda: Match(UNKNOWN))
 
 
 def is_safe_name(name: str, root: Path) -> bool:
@@ -250,8 +254,45 @@ def list_candidates(download: Path) -> list[str]:
     return _source_for(download).names()
 
 
+def verify_set(source, members, dats) -> Match:
+    """What a DAT says about the files that are about to be imported.
+
+    Verified means **every** member matched. Redump lists each track of a disc
+    as its own `<rom>`, so a cue with a good checksum beside a corrupt track
+    is not a good import -- and reporting the set on the strength of its first
+    member is how that would be missed.
+
+    Read from the source rather than the destination on purpose: it is the
+    same bytes, and doing it here means a refusal can happen before anything
+    is written.
+    """
+    if dats is None:
+        return Match(UNKNOWN)
+    verdicts = []
+    for member in members:
+        try:
+            data = source.read(member)
+        except Exception:
+            return Match(UNKNOWN, detail=f"could not read {member!r} to verify")
+        if data is None:
+            return Match(UNKNOWN, detail=f"could not read {member!r} to verify")
+        suffix = Path(member.replace("\\", "/")).suffix
+        verdicts.append(dats.lookup(**hash_bytes(data, suffix=suffix)))
+
+    if not verdicts:
+        return Match(UNKNOWN)
+    bad = next((v for v in verdicts if v.status == BAD_DUMP), None)
+    if bad is not None:
+        return bad
+    if all(v.status == VERIFIED for v in verdicts):
+        # Every member matched; name the game they all belong to.
+        return verdicts[0]
+    return Match(UNKNOWN)
+
+
 def import_rom(download: Path, platform: Platform, library_root: Path, *,
-               overwrite: bool = False) -> ImportResult:
+               overwrite: bool = False, dats=None,
+               require_verified: bool = False) -> ImportResult:
     """Place the ROM from a finished download into RomM's library.
 
     A cartridge lands as one file, exactly as before. A disc lands as a
@@ -285,6 +326,15 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
             f"no {platform.name} ROM among {len(candidates)} file(s)",
         )
 
+    # Verify before writing, so `require_verified` can refuse without leaving
+    # a rejected dump behind for somebody to find later and wonder about.
+    verdict = verify_set(source, chosen.members, dats)
+    if require_verified and verdict.status != VERIFIED:
+        return ImportResult(
+            False, None,
+            f"refused: {verdict.detail or verdict}",
+            verification=verdict)
+
     target_dir = library_root / platform.slug
 
     # A set of one keeps the layout it has always had. Wrapping every
@@ -297,7 +347,7 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
             return ImportResult(False, destination, "already in the library")
         source.copy(chosen.primary, destination)
         log.info("imported %s -> %s", chosen.primary, destination)
-        return ImportResult(True, destination)
+        return ImportResult(True, destination, verification=verdict)
 
     destination = target_dir / _set_name(chosen.primary)
     if destination.exists() and any(destination.iterdir()) and not overwrite:
@@ -324,7 +374,7 @@ def import_rom(download: Path, platform: Platform, library_root: Path, *,
         written[name] = member
 
     log.info("imported %d files -> %s", len(written), destination)
-    return ImportResult(True, destination)
+    return ImportResult(True, destination, verification=verdict)
 
 
 def _set_name(primary: str) -> str:

--- a/romarr/library.py
+++ b/romarr/library.py
@@ -94,6 +94,10 @@ class ImportResult:
     #: What the DAT said about the bytes that actually landed. `unknown` when
     #: no DAT is loaded, which is the default and is not a failure.
     verification: Match = field(default_factory=lambda: Match(UNKNOWN))
+    #: What the game is, once a metadata provider has been asked. Empty
+    #: when none is configured -- metadata is an enhancement and its
+    #: absence must never look like a failed import.
+    info: dict = field(default_factory=dict)
 
 
 def is_safe_name(name: str, root: Path) -> bool:

--- a/romarr/metadata.py
+++ b/romarr/metadata.py
@@ -247,3 +247,68 @@ class Metadata:
             if info.found:
                 return GameInfo(**{**info.__dict__, "matched_by": how})
         return GameInfo(matched_by=how)
+
+
+# --- release calendar -------------------------------------------------------
+
+def _rawg_calendar(cfg: dict, start: str, end: str, limit: int) -> list[dict]:
+    key = str(cfg.get("api_key") or "")
+    if not key:
+        return []
+    url = ("https://api.rawg.io/api/games?"
+           + urllib.parse.urlencode({
+               "key": key, "dates": f"{start},{end}",
+               "ordering": "released", "page_size": limit}))
+    body = _get_json(url) or {}
+    out = []
+    for row in body.get("results") or []:
+        out.append({
+            "title": str(row.get("name") or ""),
+            "released": str(row.get("released") or ""),
+            "rating": float(row.get("rating") or 0.0),
+            "cover_url": str(row.get("background_image") or ""),
+            "platforms": [str((p.get("platform") or {}).get("name") or "")
+                          for p in (row.get("platforms") or [])],
+            "source": "RAWG",
+        })
+    return out
+
+
+#: Which providers can answer a date range. RAWG can; IGDB's date filtering
+#: needs a different query shape and is not worth a second code path until
+#: somebody asks for it.
+CALENDAR_PROVIDERS = {"rawg": _rawg_calendar}
+
+
+def calendar(providers: list[dict], *, days_back: int = 30,
+             days_ahead: int = 60, limit: int = 40) -> dict:
+    """Games released recently or due soon.
+
+    A window in both directions on purpose. "Upcoming" alone is the obvious
+    reading and the less useful one -- most of what somebody wants to acquire
+    came out last month, not next month.
+    """
+    import datetime
+
+    today = datetime.date.today()
+    start = (today - datetime.timedelta(days=days_back)).isoformat()
+    end = (today + datetime.timedelta(days=days_ahead)).isoformat()
+
+    for cfg in providers or []:
+        if not cfg.get("enable", True):
+            continue
+        answer = CALENDAR_PROVIDERS.get(str(cfg.get("type") or "").lower())
+        if answer is None:
+            continue
+        try:
+            rows = answer(cfg, start, end, limit)
+        except Exception as exc:
+            log.warning("calendar lookup failed: %s", exc)
+            continue
+        if rows:
+            today_iso = today.isoformat()
+            for row in rows:
+                row["upcoming"] = bool(row.get("released", "") > today_iso)
+            return {"items": rows, "from": start, "to": end, "error": None}
+    return {"items": [], "from": start, "to": end,
+            "error": "no metadata provider with an API key is configured"}

--- a/romarr/metadata.py
+++ b/romarr/metadata.py
@@ -1,0 +1,249 @@
+"""Naming a game, from a hash rather than from a filename.
+
+Every tool in this category matches metadata by parsing the release title:
+strip the scene tags, strip the region, strip the revision, hope what is left
+is the game. It mostly works, and when it does not it fails silently -- a
+cover for the wrong game looks exactly like a cover for the right one.
+
+ROMarr does not have to guess. When a file verified against a No-Intro or
+Redump DAT, its **canonical name is known exactly**, so the lookup key is a
+fact rather than the output of a regular expression:
+
+    Chrono.Trigger.USA.Retranslated.v1.2.[!].smc
+      -> filename parsing: "Chrono Trigger Retranslated v1 2"
+      -> DAT verification:  "Chrono Trigger (USA)"
+
+That is the whole idea, and it is why `identify` takes a verification result
+before it takes a filename. Filename parsing is still here, because an
+unverified file has nothing else -- but it is the fallback, not the method.
+
+Providers are a driver table like the indexers and notifiers. Nothing here
+ships an API key, and a provider with no key configured is skipped rather
+than failing the lookup: metadata is an enhancement, and a missing cover must
+never cost somebody an import.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+TIMEOUT = 20
+
+
+@dataclass(frozen=True)
+class GameInfo:
+    """What a provider knows about a game."""
+
+    title: str = ""
+    summary: str = ""
+    released: str = ""
+    rating: float = 0.0
+    genres: tuple[str, ...] = ()
+    cover_url: str = ""
+    source: str = ""
+    #: How the lookup key was arrived at. Kept because "we matched a DAT name"
+    #: and "we guessed from the filename" deserve different amounts of trust,
+    #: and a UI that shows metadata without saying which is inviting somebody
+    #: to believe the wrong cover.
+    matched_by: str = ""
+
+    @property
+    def found(self) -> bool:
+        return bool(self.title)
+
+
+# --- turning a file into a search term -------------------------------------
+
+#: Everything that is decoration on a release name. Order matters: the
+#: bracketed groups go before the dotted separators, or `(USA, Europe)`
+#: becomes `USA Europe` and survives as words.
+_BRACKETED = re.compile(r"[\(\[\{][^\)\]\}]*[\)\]\}]")
+_SCENE_TAGS = re.compile(
+    r"\b(?:usa|europe|japan|world|ntsc|pal|rev\s*\d+|v\d+(?:\.\d+)*|"
+    r"proto|beta|demo|sample|unl|alt|fixed|cracked|repack|multi\d*)\b",
+    re.IGNORECASE)
+_UNDERSCORES = re.compile(r"_+")
+_DOTS = re.compile(r"\.+")
+_SPACES = re.compile(r"\s+")
+
+
+def clean_title(name: str) -> str:
+    """A searchable title from a filename, for when there is nothing better.
+
+    This is the method every other tool uses as its *only* method. Here it is
+    the fallback, and `identify` records that it was used.
+
+    **Dots are collapsed last, and that ordering is load-bearing.** A scene
+    name writes the version as `v1.1`, so replacing separators first turns it
+    into `v1 1`; the tag pattern then matches `v1`, strips it, and leaves an
+    orphan `1` welded to the title -- `Chrono Trigger 1`, which is a different
+    game. Version tags have to be matched while their dots are still there.
+    """
+    text = str(name or "")
+    text = re.sub(r"\.[A-Za-z0-9]{1,5}$", "", text)      # extension
+    text = _BRACKETED.sub(" ", text)
+    text = _UNDERSCORES.sub(" ", text)
+    text = _SCENE_TAGS.sub(" ", text)                    # while dots survive
+    text = _DOTS.sub(" ", text)
+    text = _SPACES.sub(" ", text).strip(" -–—")
+    return text
+
+
+#: A No-Intro / Redump name is `Game Name (Region) (Extras)`. The part before
+#: the first parenthesis is the title, exactly, with no guessing at all.
+_DAT_TITLE = re.compile(r"^([^(\[]+)")
+
+
+def title_from_dat(game: str) -> str:
+    found = _DAT_TITLE.match(str(game or "").strip())
+    return _SPACES.sub(" ", found.group(1)).strip() if found else ""
+
+
+def lookup_key(verification=None, filename: str = "") -> tuple[str, str]:
+    """(search term, how it was arrived at).
+
+    The DAT name wins whenever there is one. It is the difference between a
+    key that is known and a key that is inferred, and it is the only thing
+    here that makes ROMarr's metadata better rather than merely present.
+    """
+    game = getattr(verification, "game", "") or ""
+    status = getattr(verification, "status", "") or ""
+    if status == "verified" and game:
+        title = title_from_dat(game)
+        if title:
+            return title, "dat"
+    cleaned = clean_title(filename)
+    return cleaned, "filename" if cleaned else ""
+
+
+# --- providers --------------------------------------------------------------
+
+def _get_json(url: str, headers: dict | None = None):
+    request = urllib.request.Request(url)
+    for name, value in (headers or {}).items():
+        request.add_header(name, value)
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        log.warning("metadata lookup rejected: HTTP %s", exc.code)
+    except Exception as exc:
+        log.warning("metadata lookup failed: %s", exc)
+    return None
+
+
+def _rawg(cfg: dict, term: str) -> GameInfo:
+    key = str(cfg.get("api_key") or "")
+    if not key:
+        return GameInfo()
+    url = ("https://api.rawg.io/api/games?"
+           + urllib.parse.urlencode({"key": key, "search": term,
+                                     "page_size": 1, "search_exact": "true"}))
+    body = _get_json(url) or {}
+    rows = body.get("results") or []
+    if not rows:
+        return GameInfo()
+    row = rows[0]
+    return GameInfo(
+        title=str(row.get("name") or ""),
+        released=str(row.get("released") or ""),
+        rating=float(row.get("rating") or 0.0),
+        genres=tuple(str(g.get("name")) for g in (row.get("genres") or [])
+                     if g.get("name")),
+        cover_url=str(row.get("background_image") or ""),
+        source="RAWG",
+    )
+
+
+def _igdb(cfg: dict, term: str) -> GameInfo:
+    """IGDB, which needs a Twitch client id and a bearer token.
+
+    ROMarr does not fetch the token: it is an OAuth client-credentials
+    exchange that belongs in the operator's own setup, and a tool that quietly
+    holds a Twitch credential to make cover art appear is doing more than
+    anybody asked.
+    """
+    client_id = str(cfg.get("client_id") or "")
+    token = str(cfg.get("token") or "")
+    if not (client_id and token):
+        return GameInfo()
+    request = urllib.request.Request(
+        "https://api.igdb.com/v4/games",
+        data=(f'search "{term}"; fields name,summary,first_release_date,'
+              f'rating,genres.name,cover.url; limit 1;').encode(),
+        method="POST")
+    request.add_header("Client-ID", client_id)
+    request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            rows = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        log.warning("IGDB lookup failed: %s", exc)
+        return GameInfo()
+    if not rows:
+        return GameInfo()
+    row = rows[0]
+    cover = (row.get("cover") or {}).get("url") or ""
+    return GameInfo(
+        title=str(row.get("name") or ""),
+        summary=str(row.get("summary") or ""),
+        rating=float(row.get("rating") or 0.0) / 10.0,
+        genres=tuple(str(g.get("name")) for g in (row.get("genres") or [])
+                     if g.get("name")),
+        # IGDB returns protocol-relative URLs and a thumbnail size by default.
+        cover_url=("https:" + cover.replace("t_thumb", "t_cover_big")
+                   if cover.startswith("//") else cover),
+        source="IGDB",
+    )
+
+
+PROVIDERS: dict[str, dict] = {
+    "rawg": {"label": "RAWG.io", "lookup": _rawg, "fields": ("api_key",),
+             "help": "A free RAWG API key."},
+    "igdb": {"label": "IGDB", "lookup": _igdb,
+             "fields": ("client_id", "token"),
+             "help": "A Twitch client id and bearer token. ROMarr does not "
+                     "perform the OAuth exchange for you."},
+}
+
+
+@dataclass
+class Metadata:
+    """Every configured provider, asked in order until one answers."""
+
+    providers: list[dict] = field(default_factory=list)
+
+    def identify(self, *, verification=None, filename: str = "") -> GameInfo:
+        """What this file is, named from the strongest key available.
+
+        Never raises and never blocks an import. Metadata is an enhancement;
+        a missing cover must not cost somebody a game.
+        """
+        term, how = lookup_key(verification, filename)
+        if not term:
+            return GameInfo()
+
+        for cfg in self.providers:
+            if not cfg.get("enable", True):
+                continue
+            spec = PROVIDERS.get(str(cfg.get("type") or "").lower())
+            if spec is None:
+                log.warning("unknown metadata provider %r", cfg.get("type"))
+                continue
+            try:
+                info = spec["lookup"](cfg, term)
+            except Exception as exc:
+                log.warning("metadata provider %r raised: %s",
+                            cfg.get("type"), exc)
+                continue
+            if info.found:
+                return GameInfo(**{**info.__dict__, "matched_by": how})
+        return GameInfo(matched_by=how)

--- a/romarr/notify.py
+++ b/romarr/notify.py
@@ -1,0 +1,280 @@
+"""Telling somebody what happened.
+
+Radarr has twenty-four notification providers and gamarr has two. The number
+is not the interesting part -- almost every one of them is an HTTP POST with a
+differently-shaped body, which is why this is a driver table over one sender
+rather than twenty-four clients, the same way the indexer registry is a table
+over two protocol clients.
+
+**What is worth doing better is the message.** Every one of these tools sends
+"Grabbed: Chrono Trigger (USA)". ROMarr's scorer already knows *why* it chose
+that release and its importer knows whether the bytes verified against a DAT,
+so the notification carries both:
+
+    Grabbed Chrono Trigger (USA) [!] for Super Nintendo
+    +50 verified good dump [!], +40 region usa, +40 30 seeders
+    from RetroWithin
+
+An operator reading that can tell a good pick from a lucky one without
+opening the UI, which is the entire reason to send a message at all.
+
+Nothing here retries. A notification that failed is logged and dropped: it is
+not worth holding up an import, and a queue of stale "grabbed" messages
+arriving an hour late is worse than none.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+#: Events worth telling somebody about.
+ON_GRAB = "grab"
+ON_IMPORT = "import"
+ON_FAILURE = "failure"
+ON_UPGRADE = "upgrade"
+ON_BAD_DUMP = "bad-dump"
+
+EVENTS = (ON_GRAB, ON_IMPORT, ON_UPGRADE, ON_FAILURE, ON_BAD_DUMP)
+
+TIMEOUT = 15
+
+
+@dataclass
+class Message:
+    """One thing that happened, in a shape every provider can render."""
+
+    event: str
+    title: str
+    body: str = ""
+    #: The scorer's reasons, when there are any. This is the part other tools
+    #: do not have and cannot add: it comes from `Judgement.why()`.
+    reasons: tuple[str, ...] = ()
+    url: str = ""
+
+    def text(self) -> str:
+        lines = [self.title]
+        if self.body:
+            lines.append(self.body)
+        lines.extend(self.reasons)
+        return "\n".join(lines)
+
+
+def _post(url: str, *, data: bytes | None = None, headers: dict | None = None,
+          method: str = "POST") -> bool:
+    request = urllib.request.Request(url, data=data, method=method)
+    for name, value in (headers or {}).items():
+        request.add_header(name, value)
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            return 200 <= response.status < 300
+    except urllib.error.HTTPError as exc:
+        log.warning("notification to %s rejected: HTTP %s",
+                    _safe(url), exc.code)
+    except Exception as exc:                    # a down endpoint is routine
+        log.warning("notification to %s failed: %s", _safe(url), exc)
+    return False
+
+
+def _safe(url: str) -> str:
+    """A URL fit for a log. Discord and Slack webhook paths ARE the credential."""
+    parts = urllib.parse.urlsplit(str(url or ""))
+    return f"{parts.scheme}://{parts.netloc}/…" if parts.netloc else "the endpoint"
+
+
+def _json_post(url: str, payload: dict, headers: dict | None = None) -> bool:
+    return _post(url, data=json.dumps(payload).encode(),
+                 headers={"Content-Type": "application/json", **(headers or {})})
+
+
+# --- providers -------------------------------------------------------------
+#
+# Each takes (config, message) and returns whether it was delivered.
+
+def _discord(cfg: dict, message: Message) -> bool:
+    payload = {"content": message.text()[:1900]}
+    if cfg.get("username"):
+        payload["username"] = cfg["username"]
+    return _json_post(cfg.get("url", ""), payload)
+
+
+def _slack(cfg: dict, message: Message) -> bool:
+    return _json_post(cfg.get("url", ""), {"text": message.text()})
+
+
+def _webhook(cfg: dict, message: Message) -> bool:
+    """A generic webhook gets the structured event, not a rendered string.
+
+    Anything consuming this is a program, and handing it prose to parse back
+    into fields is the thing that makes generic webhooks useless.
+    """
+    return _json_post(cfg.get("url", ""), {
+        "event": message.event, "title": message.title,
+        "body": message.body, "reasons": list(message.reasons),
+        "url": message.url,
+    })
+
+
+def _ntfy(cfg: dict, message: Message) -> bool:
+    headers = {"Title": message.title, "Content-Type": "text/plain"}
+    if cfg.get("token"):
+        headers["Authorization"] = f"Bearer {cfg['token']}"
+    if cfg.get("priority"):
+        headers["Priority"] = str(cfg["priority"])
+    body = "\n".join([message.body, *message.reasons]).strip() or message.title
+    return _post(cfg.get("url", ""), data=body.encode(), headers=headers)
+
+
+def _gotify(cfg: dict, message: Message) -> bool:
+    base = str(cfg.get("url", "")).rstrip("/")
+    token = urllib.parse.quote(str(cfg.get("token", "")))
+    return _json_post(f"{base}/message?token={token}",
+                      {"title": message.title,
+                       "message": "\n".join([message.body, *message.reasons]).strip(),
+                       "priority": int(cfg.get("priority") or 5)})
+
+
+def _telegram(cfg: dict, message: Message) -> bool:
+    token = str(cfg.get("token", ""))
+    return _json_post(f"https://api.telegram.org/bot{token}/sendMessage",
+                      {"chat_id": cfg.get("chat_id", ""),
+                       "text": message.text(),
+                       "disable_web_page_preview": True})
+
+
+def _pushover(cfg: dict, message: Message) -> bool:
+    data = urllib.parse.urlencode({
+        "token": cfg.get("token", ""), "user": cfg.get("user", ""),
+        "title": message.title,
+        "message": "\n".join([message.body, *message.reasons]).strip(),
+    }).encode()
+    return _post("https://api.pushover.net/1/messages.json", data=data,
+                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+
+
+def _apprise(cfg: dict, message: Message) -> bool:
+    """An Apprise API server, which is itself a fan-out to a hundred more.
+
+    Worth carrying because it makes "every provider Radarr has" a
+    configuration question rather than a code question.
+    """
+    base = str(cfg.get("url", "")).rstrip("/")
+    payload = {"body": "\n".join([message.body, *message.reasons]).strip()
+                       or message.title,
+               "title": message.title, "type": "info"}
+    if cfg.get("urls"):
+        payload["urls"] = cfg["urls"]
+    return _json_post(f"{base}/notify", payload)
+
+
+NOTIFIERS: dict[str, dict] = {
+    "discord": {"label": "Discord", "send": _discord,
+                "fields": ("url", "username"),
+                "help": "A Discord channel webhook URL."},
+    "slack": {"label": "Slack", "send": _slack, "fields": ("url",),
+              "help": "A Slack incoming-webhook URL."},
+    "webhook": {"label": "Webhook", "send": _webhook, "fields": ("url",),
+                "help": "Receives the structured event as JSON."},
+    "ntfy": {"label": "ntfy.sh", "send": _ntfy,
+             "fields": ("url", "token", "priority"),
+             "help": "The full topic URL, e.g. https://ntfy.sh/my-topic."},
+    "gotify": {"label": "Gotify", "send": _gotify,
+               "fields": ("url", "token", "priority"),
+               "help": "Server URL plus an application token."},
+    "telegram": {"label": "Telegram", "send": _telegram,
+                 "fields": ("token", "chat_id"),
+                 "help": "A bot token and the chat id to post into."},
+    "pushover": {"label": "Pushover", "send": _pushover,
+                 "fields": ("token", "user"),
+                 "help": "Application token and user key."},
+    "apprise": {"label": "Apprise", "send": _apprise,
+                "fields": ("url", "urls"),
+                "help": "An Apprise API server, which fans out to a hundred "
+                        "more services."},
+}
+
+
+@dataclass
+class Notifier:
+    """Every configured connection, fanned out to."""
+
+    connections: list[dict] = field(default_factory=list)
+
+    def send(self, message: Message) -> list[dict]:
+        """Deliver to every connection subscribed to this event.
+
+        Never raises. One provider being down must not fail an import that
+        already succeeded -- the delivery is a courtesy, the import is the
+        work.
+        """
+        out = []
+        for cfg in self.connections:
+            if not cfg.get("enable", True):
+                continue
+            if not self.wants(cfg, message.event):
+                continue
+            spec = NOTIFIERS.get(str(cfg.get("type") or "").lower())
+            if spec is None:
+                log.warning("unknown notification type %r", cfg.get("type"))
+                continue
+            try:
+                ok = bool(spec["send"](cfg, message))
+            except Exception as exc:
+                log.warning("notification %r raised: %s", cfg.get("name"), exc)
+                ok = False
+            out.append({"name": cfg.get("name") or spec["label"], "ok": ok})
+        return out
+
+    @staticmethod
+    def wants(cfg: dict, event: str) -> bool:
+        """Whether this connection subscribes to this event.
+
+        A connection with no `events` key gets everything. That is the useful
+        default -- somebody who just pasted a Discord webhook wants to be told
+        things -- and an empty list means exactly what it says: nothing.
+        """
+        events = cfg.get("events")
+        if events is None:
+            return True
+        return event in events
+
+
+def grabbed(title: str, platform: str, indexer: str, reasons) -> Message:
+    """The message other tools cannot send.
+
+    Radarr tells you it grabbed something. This tells you what it weighed,
+    which is the difference between trusting the automation and checking it.
+    """
+    return Message(
+        event=ON_GRAB,
+        title=f"Grabbed {title}",
+        body=f"{platform} — from {indexer}" if platform else f"from {indexer}",
+        reasons=tuple(reasons or ()),
+    )
+
+
+def imported(title: str, platform: str, verification) -> Message:
+    status = getattr(verification, "status", "") or ""
+    detail = getattr(verification, "detail", "") or ""
+    game = getattr(verification, "game", "") or ""
+    if status == "verified":
+        note = f"verified against DAT as {game}" if game else "verified"
+        event = ON_IMPORT
+    elif status == "bad-dump":
+        note = f"BAD DUMP — {detail}"
+        event = ON_BAD_DUMP
+    else:
+        note = "not in any loaded DAT"
+        event = ON_IMPORT
+    return Message(event=event, title=f"Imported {title}",
+                   body=f"{platform} — {note}" if platform else note)
+
+
+def failed(title: str, reason: str) -> Message:
+    return Message(event=ON_FAILURE, title=f"Failed {title}", body=reason)

--- a/romarr/ops.py
+++ b/romarr/ops.py
@@ -1,0 +1,218 @@
+"""Operating ROMarr: metrics, rate limiting, backup and export.
+
+Four things every mature *arr has and none of which is clever. What they have
+in common is that each one is trivial to get subtly wrong in a way nobody
+notices until the day it matters:
+
+  * a metrics endpoint that is open when the rest of the app is not,
+  * a rate limiter that counts the wrong thing and locks out the operator,
+  * a backup that quietly contains every password in plain text,
+  * an export that corrupts a title containing a comma.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+
+# --- Prometheus -------------------------------------------------------------
+
+def _escape(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+
+
+def render_metrics(stats: dict) -> str:
+    """Prometheus text exposition, built from a plain dict.
+
+    Deliberately not a client library. The format is six lines of rules, and
+    the dependency would be larger than the feature -- ROMarr is stdlib plus
+    `requests` and that is worth keeping.
+    """
+    lines: list[str] = []
+
+    def emit(name: str, kind: str, help_text: str, value, labels=None):
+        full = f"romarr_{name}"
+        if not any(line.startswith(f"# TYPE {full} ") for line in lines):
+            lines.append(f"# HELP {full} {help_text}")
+            lines.append(f"# TYPE {full} {kind}")
+        if labels:
+            rendered = ",".join(f'{k}="{_escape(v)}"' for k, v in labels.items())
+            lines.append(f"{full}{{{rendered}}} {value}")
+        else:
+            lines.append(f"{full} {value}")
+
+    emit("up", "gauge", "Always 1; scrape failure is the signal for down.", 1)
+    emit("platforms", "gauge", "Platforms ROMarr can request.",
+         int(stats.get("platforms") or 0))
+    emit("queue_size", "gauge", "Items currently queued.",
+         int(stats.get("queued") or 0))
+    emit("library_items", "gauge", "ROMs known in the library.",
+         int(stats.get("library_items") or 0))
+    emit("wanted_items", "gauge", "Games wanted but not yet found.",
+         int(stats.get("wanted") or 0))
+    emit("blocklist_size", "gauge", "Releases that will never be taken.",
+         int(stats.get("blocklist") or 0))
+    emit("uptime_seconds", "counter", "Seconds since start.",
+         int(stats.get("uptime_seconds") or 0))
+
+    for name, ok in (stats.get("dependencies") or {}).items():
+        emit("dependency_up", "gauge",
+             "1 when a configured dependency answered.",
+             1 if ok else 0, {"name": name})
+
+    # Import outcomes by DAT verdict. This is the series no other tool in this
+    # category can publish, and the one worth alerting on: a rising
+    # `verified="bad-dump"` means an indexer has started serving corrupt
+    # dumps, which nothing else would surface until somebody pressed play.
+    for verdict, count in (stats.get("imports") or {}).items():
+        emit("imports_total", "counter",
+             "Imports by DAT verification verdict.",
+             int(count), {"verdict": verdict})
+
+    return "\n".join(lines) + "\n"
+
+
+# --- rate limiting ----------------------------------------------------------
+
+#: Per-category limits, as (requests, seconds).
+#:
+#: Login is far tighter than the rest because it is the only endpoint where
+#: guessing is the attack. Search is limited because each one fans out to
+#: every configured indexer, so an unbounded caller does not hammer ROMarr --
+#: it hammers somebody else's tracker, and gets the operator banned.
+DEFAULT_LIMITS = {
+    "login": (5, 60),
+    "search": (30, 60),
+    "download": (60, 60),
+    "general": (300, 60),
+}
+
+
+class RateLimiter:
+    """A fixed-window-per-key counter.
+
+    Keyed on category *and* caller, never on category alone: a shared counter
+    means one noisy script locks the operator out of their own UI, which is a
+    denial of service the limiter introduced rather than prevented.
+    """
+
+    def __init__(self, limits: dict | None = None, clock=time.monotonic):
+        self.limits = dict(limits or DEFAULT_LIMITS)
+        self._clock = clock
+        self._hits: dict[tuple[str, str], deque] = {}
+
+    def check(self, category: str, caller: str = "") -> tuple[bool, int]:
+        """(allowed, seconds until it would be allowed)."""
+        limit, window = self.limits.get(category, self.limits["general"])
+        key = (category, caller or "")
+        now = self._clock()
+        hits = self._hits.setdefault(key, deque())
+        while hits and now - hits[0] >= window:
+            hits.popleft()
+        if len(hits) >= limit:
+            return False, max(1, int(window - (now - hits[0])))
+        hits.append(now)
+        return True, 0
+
+    @staticmethod
+    def category_for(path: str) -> str:
+        path = str(path or "")
+        if "/login" in path:
+            return "login"
+        if "/search" in path or "/release" in path or "/candidates" in path:
+            return "search"
+        if "/grab" in path or "/download" in path or "/queue" in path:
+            return "download"
+        return "general"
+
+
+# --- backup and restore -----------------------------------------------------
+
+#: Settings a backup must never contain.
+#:
+#: A backup is copied to another machine, emailed to somebody helping with a
+#: problem, and committed to a private repo "just in case". Every one of those
+#: is a place a plaintext qBittorrent password should not be, and a backup
+#: that silently carries credentials is worse than no backup because it is
+#: handled as though it were harmless.
+SECRET_KEYS = ("_api_key", "_password_hash", "_totp_secret", "_totp_backup")
+SECRET_FIELDS = ("password", "api_key", "passkey", "token", "secret")
+
+
+def _strip_secrets(value):
+    if isinstance(value, dict):
+        return {k: ("" if k in SECRET_FIELDS or k in SECRET_KEYS
+                    else _strip_secrets(v))
+                for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_secrets(v) for v in value]
+    return value
+
+
+def make_backup(settings: dict, *, include_secrets: bool = False) -> dict:
+    """A restorable snapshot of the configuration.
+
+    Credentials are stripped unless explicitly asked for, and the result says
+    which it is -- so a restore can warn that the download clients will need
+    their passwords again rather than silently producing an install that
+    cannot log in to anything.
+    """
+    body = dict(settings)
+    if not include_secrets:
+        body = _strip_secrets(body)
+    return {
+        "kind": "romarr-backup",
+        "version": 1,
+        "created_at": int(time.time()),
+        "contains_secrets": bool(include_secrets),
+        "settings": body,
+    }
+
+
+def read_backup(payload) -> tuple[dict, str]:
+    """(settings, warning). Raises ValueError on anything that is not a backup."""
+    if isinstance(payload, (str, bytes)):
+        payload = json.loads(payload)
+    if not isinstance(payload, dict) or payload.get("kind") != "romarr-backup":
+        raise ValueError("not a ROMarr backup")
+    settings = payload.get("settings")
+    if not isinstance(settings, dict):
+        raise ValueError("backup contains no settings")
+    warning = ""
+    if not payload.get("contains_secrets"):
+        warning = ("This backup was taken without credentials. Download "
+                   "clients, indexers and libraries will need their passwords "
+                   "and API keys entered again.")
+    return settings, warning
+
+
+# --- export -----------------------------------------------------------------
+
+def to_csv(rows: list[dict], columns: list[str] | None = None) -> str:
+    """CSV via the stdlib writer, never string joining.
+
+    Game titles contain commas, quotes and the occasional newline --
+    "Ratchet & Clank: Up Your Arsenal", "Bust-A-Move '99" -- and hand-rolled
+    CSV corrupts exactly those rows while looking correct for everything else.
+    `\\r\\n` because that is what RFC 4180 says and what spreadsheets expect.
+    """
+    columns = columns or sorted({k for row in rows for k in row})
+    out = io.StringIO()
+    writer = csv.DictWriter(out, fieldnames=columns, extrasaction="ignore",
+                            lineterminator="\r\n")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({c: row.get(c, "") for c in columns})
+    return out.getvalue()
+
+
+def from_csv(text: str) -> list[dict]:
+    return [dict(row) for row in csv.DictReader(io.StringIO(text or ""))]

--- a/romarr/profiles.py
+++ b/romarr/profiles.py
@@ -1,0 +1,181 @@
+"""Operator policy over the scorer.
+
+Two things every *arr has and ROMarr did not: a way to say "prefer this, never
+that", and a way to say "never offer me this exact release again".
+
+Both exist elsewhere as flat lists -- a set of words, a set of ids. The
+difference here is that ROMarr's scorer already explains itself release by
+release, so both of these can be *visible*:
+
+  * a preferred term appears in `Judgement.why()` with the points it added, so
+    an operator can see their own policy working rather than infer it from a
+    changed outcome;
+  * a blocklist entry carries the reason it was blocked and when, so "why will
+    it never take this one" has an answer that is not "look in the logs".
+
+"Why did it take that one" and "why will it never take this one" are the two
+questions anybody actually asks about an *arr, and a flat list answers
+neither.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+#: A term wrapped in slashes is a regular expression, the way Radarr's release
+#: profiles work. The cases that need one are real: `(Rev 1)` but not
+#: `(Rev 10)` cannot be expressed as a substring.
+_REGEX_TERM = re.compile(r"^/(.*)/$", re.DOTALL)
+
+
+def _matches(term: str, haystack: str) -> bool:
+    """Whether `term` -- literal or `/regex/` -- appears in `haystack`."""
+    term = str(term or "")
+    if not term:
+        return False
+    pattern = _REGEX_TERM.match(term)
+    if pattern:
+        try:
+            return re.search(pattern.group(1), haystack, re.IGNORECASE) is not None
+        except re.error as exc:
+            # A bad pattern is an operator typo, and taking every search down
+            # with it would turn a one-character mistake into a dead install.
+            log.warning("ignoring unparseable release-profile term %r: %s",
+                        term, exc)
+            return False
+    return term.lower() in haystack
+
+
+@dataclass
+class ReleaseProfile:
+    """Preferred, excluded and required terms.
+
+    `preferred` carries its own weight per term rather than a single global
+    bonus, because "I mildly like this" and "I will take nothing else" are
+    different instructions and one number cannot express both.
+    """
+
+    #: (term, points). Negative is a penalty, which is how "avoid but do not
+    #: refuse" is written.
+    preferred: list[tuple[str, int]] = field(default_factory=list)
+    #: Any match refuses the release outright.
+    excluded: list[str] = field(default_factory=list)
+    #: Every term must appear, or the release is refused.
+    required: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_settings(cls, settings: dict) -> "ReleaseProfile":
+        """Build from stored settings, tolerating whatever shape they are in.
+
+        Preferred terms are stored as a list of `{term, score}` because a UI
+        edits them as rows, and a tuple in JSON comes back as a list.
+        """
+        preferred = []
+        for entry in settings.get("preferred_terms") or []:
+            if isinstance(entry, dict):
+                term = str(entry.get("term") or "")
+                try:
+                    points = int(entry.get("score") or 0)
+                except (TypeError, ValueError):
+                    points = 0
+            elif isinstance(entry, (list, tuple)) and len(entry) == 2:
+                term, points = str(entry[0]), int(entry[1] or 0)
+            else:
+                term, points = str(entry), 25
+            if term:
+                preferred.append((term, points))
+        return cls(
+            preferred=preferred,
+            excluded=[str(t) for t in (settings.get("excluded_terms") or []) if t],
+            required=[str(t) for t in (settings.get("required_terms") or []) if t],
+        )
+
+    def refusal(self, lowered: str) -> str:
+        """Why this release is refused outright, or "" if it is not."""
+        for term in self.excluded:
+            if _matches(term, lowered):
+                return f"excluded by release profile ({term!r})"
+        for term in self.required:
+            if not _matches(term, lowered):
+                return f"missing a required term ({term!r})"
+        return ""
+
+    def adjustments(self, lowered: str) -> list[tuple[int, str]]:
+        """Point changes this profile makes, ready for `Judgement.reasons`."""
+        out = []
+        for term, points in self.preferred:
+            if points and _matches(term, lowered):
+                out.append((points, f"release profile prefers {term!r}"))
+        return out
+
+    def __bool__(self) -> bool:
+        return bool(self.preferred or self.excluded or self.required)
+
+
+_INFOHASH = re.compile(r"btih:([0-9a-fA-F]{40}|[0-9a-zA-Z]{32})")
+
+
+def release_id(release) -> str:
+    """A stable identity for one release.
+
+    The infohash when there is one, because indexers rewrite titles freely and
+    two results for the same torrent have to block as one. Otherwise the
+    indexer, title and size together -- enough that a re-run of the same search
+    recognises the same entry, and specific enough that a different dump of the
+    same game is not caught by mistake.
+    """
+    found = _INFOHASH.search(str(getattr(release, "download_url", "") or ""))
+    if found:
+        return f"btih:{found.group(1).lower()}"
+    return (f"{getattr(release, 'indexer', '')}|"
+            f"{getattr(release, 'title', '')}|"
+            f"{getattr(release, 'size', 0)}").lower()
+
+
+class Blocklist:
+    """Releases that must never be taken again, and why."""
+
+    def __init__(self):
+        self._entries: dict[str, dict] = {}
+
+    def add(self, release, reason: str = "") -> dict:
+        entry = {
+            "id": release_id(release),
+            "title": getattr(release, "title", ""),
+            "indexer": getattr(release, "indexer", ""),
+            "size": getattr(release, "size", 0),
+            "reason": reason or "blocked by the operator",
+            "blocked_at": int(time.time()),
+        }
+        self._entries[entry["id"]] = entry
+        return entry
+
+    def remove(self, entry_id: str) -> bool:
+        return self._entries.pop(str(entry_id), None) is not None
+
+    def reason_for(self, release) -> str:
+        entry = self._entries.get(release_id(release))
+        return entry["reason"] if entry else ""
+
+    def __contains__(self, release) -> bool:
+        return release_id(release) in self._entries
+
+    def as_items(self) -> list[dict]:
+        return sorted(self._entries.values(),
+                      key=lambda e: -e.get("blocked_at", 0))
+
+    @classmethod
+    def from_items(cls, items) -> "Blocklist":
+        out = cls()
+        for item in items or []:
+            if isinstance(item, dict) and item.get("id"):
+                out._entries[str(item["id"])] = dict(item)
+        return out
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/romarr/selection.py
+++ b/romarr/selection.py
@@ -241,8 +241,23 @@ class Judgement:
 
 
 def judge(release: Release, wanted: str,
-          platform: Platform | None = None) -> Judgement:
-    """Rank a release and record why. Higher is better; negative means no."""
+          platform: Platform | None = None, *,
+          profile=None, blocklist=None) -> Judgement:
+    """Rank a release and record why. Higher is better; negative means no.
+
+    `profile` and `blocklist` are operator policy and are applied before any
+    scoring. A blocked release is refused even when a profile scores it
+    highly: somebody who preferred a term and then blocked a specific release
+    meant the block, and reading it the other way round is the worst available
+    interpretation.
+    """
+    if blocklist is not None and release in blocklist:
+        return Judgement(-2000,
+                         verdict=f"blocklisted: {blocklist.reason_for(release)}")
+    if profile:
+        refusal = profile.refusal(release.title.lower())
+        if refusal:
+            return Judgement(-900, verdict=refusal)
     if not is_game_release(release):
         return Judgement(-1000, verdict="not a game release (wrong category)")
     if not title_matches(release.title, wanted):
@@ -395,6 +410,10 @@ def judge(release: Release, wanted: str,
             # those imports cleanly and boots nothing.
             add(-200, f"too small to be a {platform.name} {medium}")
 
+    if profile:
+        for delta, text in profile.adjustments(lowered):
+            add(delta, text)
+
     return Judgement(points, tuple(reasons))
 
 
@@ -422,9 +441,11 @@ def explain(release: Release, wanted: str,
 
 
 def best_release(releases: list[Release], wanted: str,
-                 platform: Platform | None = None) -> Release | None:
+                 platform: Platform | None = None, *,
+                 profile=None, blocklist=None) -> Release | None:
     """The highest-scoring usable release, or None if nothing qualifies."""
-    ranked = [(score(r, wanted, platform), r) for r in releases]
+    ranked = [(judge(r, wanted, platform, profile=profile,
+                     blocklist=blocklist).points, r) for r in releases]
     ranked = [(s, r) for s, r in ranked if s > 0]
     if not ranked:
         return None

--- a/romarr/sso.py
+++ b/romarr/sso.py
@@ -1,0 +1,194 @@
+"""Believing an identity your reverse proxy already established.
+
+Authentik, Authelia, oauth2-proxy and Cloudflare Access all work the same way:
+they authenticate the user, then forward the request with a header naming
+them. The application's job is to believe that header -- **and only from the
+proxy.**
+
+That qualifier is the entire security of the arrangement, and it is why this
+module exists rather than a two-line header read. A header is text anybody can
+send. An app that believes `X-authentik-username` from any source has not
+added single sign-on; it has added a way to become any user by typing one
+header:
+
+    curl -H 'X-authentik-username: admin' http://romarr:6868/api/v1/config
+
+So every identity is gated on the *socket peer* being inside a configured
+trusted range. Not `X-Forwarded-For` -- that is client-controlled too, and
+reading the peer out of it reintroduces the same bypass through the back door.
+
+It also replaces the blunt instrument it grew out of. `ROMARR_AUTH=disabled`
+exists for installs behind an authenticating proxy, and it is honest about
+what it does: ROMarr stops checking anything, and any request that reaches the
+port is in. Forward auth is the same deployment done properly -- the proxy is
+still the authority, but ROMarr verifies the request came *through* it, learns
+who the user is, and can require a group.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+#: The headers each product really sends. Getting one of these wrong produces
+#: an install that authenticates correctly and then reports every request as
+#: anonymous, which reads as "SSO does not work" rather than "wrong header".
+FORWARD_PROVIDERS: dict[str, dict] = {
+    "authentik": {
+        "label": "Authentik",
+        "user_header": "X-authentik-username",
+        "email_header": "X-authentik-email",
+        "groups_header": "X-authentik-groups",
+        "help": "Authentik's proxy outpost. Groups arrive pipe-separated, and "
+                "only if the provider is configured to send them.",
+    },
+    "authelia": {
+        "label": "Authelia",
+        "user_header": "Remote-User",
+        "email_header": "Remote-Email",
+        "groups_header": "Remote-Groups",
+        "help": "Authelia's forward-auth endpoint.",
+    },
+    "oauth2-proxy": {
+        "label": "oauth2-proxy",
+        "user_header": "X-Forwarded-User",
+        "email_header": "X-Forwarded-Email",
+        "groups_header": "X-Forwarded-Groups",
+        "help": "Requires --set-xauthrequest and the headers passed through.",
+    },
+    "cloudflare-access": {
+        "label": "Cloudflare Access",
+        "user_header": "Cf-Access-Authenticated-User-Email",
+        "email_header": "Cf-Access-Authenticated-User-Email",
+        "groups_header": "",
+        "help": "Trusted proxies must be Cloudflare's ranges, not your LAN.",
+    },
+    "tinyauth": {
+        "label": "Tinyauth",
+        "user_header": "Remote-User",
+        "email_header": "Remote-Email",
+        "groups_header": "Remote-Groups",
+        "help": "Tinyauth's forward-auth headers.",
+    },
+    "custom": {
+        "label": "Custom",
+        "user_header": "X-Forwarded-User",
+        "email_header": "X-Forwarded-Email",
+        "groups_header": "X-Forwarded-Groups",
+        "help": "Name the headers your proxy sends.",
+    },
+}
+
+
+def trusted_peer(peer: str, allowed) -> bool:
+    """Whether the immediate peer is one of the configured proxies.
+
+    An empty list trusts nobody. That is deliberate and is the most important
+    default in this file: an operator who turned forward auth on and has not
+    filled in the ranges yet has an *unfinished* configuration, and reading it
+    as "trust everything" turns that into an open install at the exact moment
+    they are least likely to notice.
+    """
+    if not allowed:
+        return False
+    try:
+        address = ipaddress.ip_address(str(peer or "").strip())
+    except ValueError:
+        return False
+    for entry in allowed:
+        entry = str(entry or "").strip()
+        if not entry:
+            continue
+        try:
+            if address in ipaddress.ip_network(entry, strict=False):
+                return True
+        except ValueError:
+            log.warning("ignoring unparseable trusted proxy %r", entry)
+    return False
+
+
+@dataclass(frozen=True)
+class Identity:
+    ok: bool
+    user: str = ""
+    email: str = ""
+    groups: tuple[str, ...] = ()
+    reason: str = ""
+
+
+class ForwardAuth:
+    """Identity from a trusted proxy's headers."""
+
+    def __init__(self, provider: str = "authentik", trusted_proxies=None,
+                 user_header: str = "", groups_header: str = "",
+                 email_header: str = "", required_group: str = ""):
+        preset = FORWARD_PROVIDERS.get(provider, FORWARD_PROVIDERS["custom"])
+        self.provider = provider
+        self.trusted_proxies = list(trusted_proxies or [])
+        self.user_header = user_header or preset["user_header"]
+        self.email_header = email_header or preset["email_header"]
+        self.groups_header = groups_header or preset["groups_header"]
+        self.required_group = (required_group or "").strip()
+
+    def identify(self, headers, peer: str) -> Identity:
+        """Who this request is, or why it is nobody.
+
+        `peer` is the socket's remote address and nothing else. It is a
+        parameter rather than something read from the headers because the only
+        trustworthy answer comes from the connection itself -- see the module
+        docstring.
+        """
+        if not trusted_peer(peer, self.trusted_proxies):
+            return Identity(False, reason=f"{peer or 'the caller'} is not a "
+                                          "trusted proxy")
+        user = _header(headers, self.user_header)
+        if not user:
+            return Identity(
+                False,
+                reason=f"trusted proxy sent no identity header "
+                       f"({self.user_header}); is this path protected in the "
+                       "proxy configuration?")
+
+        groups = _groups(_header(headers, self.groups_header))
+        if self.required_group and self.required_group not in groups:
+            # A missing groups header is a refusal, not a pass. Authentik only
+            # sends groups when the provider is told to, and treating absence
+            # as "no restriction" silently disables the restriction that was
+            # asked for.
+            return Identity(
+                False, user=user, groups=groups,
+                reason=f"{user!r} is not in the required group "
+                       f"{self.required_group!r}")
+
+        return Identity(True, user=user,
+                        email=_header(headers, self.email_header),
+                        groups=groups)
+
+
+def _header(headers, name: str) -> str:
+    if not name or headers is None:
+        return ""
+    got = headers.get(name)
+    if got:
+        return str(got).strip()
+    lowered = name.lower()
+    for key, value in getattr(headers, "items", lambda: [])():
+        if str(key).lower() == lowered and value:
+            return str(value).strip()
+    return ""
+
+
+def _groups(raw: str) -> tuple[str, ...]:
+    """Group names, in whichever separator the provider chose.
+
+    Authentik pipes them, oauth2-proxy commas them, and some setups use
+    spaces. Supporting one separator means a correctly configured install
+    silently fails its group check on the other two.
+    """
+    text = str(raw or "")
+    for separator in ("|", ","):
+        text = text.replace(separator, " ")
+    return tuple(part for part in text.split() if part)

--- a/romarr/totp.py
+++ b/romarr/totp.py
@@ -1,0 +1,139 @@
+"""Time-based one-time passwords, RFC 6238.
+
+Thirty lines of HMAC and a lot of care around the edges. The algorithm is the
+easy part -- the RFC even ships test vectors, which is why they are pinned in
+the tests rather than trusting the implementation to agree with itself.
+
+What implementations get wrong is the other three things:
+
+  * **Replay.** A code is valid for its 30-second step plus the drift
+    tolerance either side. Anyone who sees one -- over a shoulder, in a proxy
+    log, in a screenshot posted for help -- can use it until it expires.
+    Accepting each code exactly once is the entire point of the counter.
+  * **Comparison.** Six digits is a small space, and a byte-by-byte `==`
+    leaks how much of a guess was right through timing.
+  * **Recovery.** A phone gets lost, and a second factor with no way past it
+    is a lockout. Backup codes are that way, and each is consumed on use --
+    a reusable one is just a password that never expires.
+
+No dependency: `hmac`, `hashlib` and `base64` are enough, and an authenticator
+app only needs the `otpauth://` URI.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+import struct
+import time
+from urllib.parse import quote
+
+#: RFC 6238 defaults, and what every authenticator app assumes.
+STEP_SECONDS = 30
+DIGITS = 6
+
+#: How many steps either side of now are accepted. Phone clocks drift and
+#: people type slowly; zero tolerance produces "my code is right and it says
+#: no" in the second either side of every boundary.
+DRIFT_STEPS = 1
+
+_B32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+
+def new_secret(length: int = 32) -> str:
+    """A fresh base32 secret, in the alphabet authenticator apps accept."""
+    return "".join(secrets.choice(_B32_ALPHABET) for _ in range(length))
+
+
+def code_at(secret: str, moment: int, *, step: int = STEP_SECONDS,
+            digits: int = DIGITS) -> str:
+    """The code for a given unix time."""
+    key = base64.b32decode(_pad(secret), casefold=True)
+    counter = struct.pack(">Q", int(moment) // step)
+    digest = hmac.new(key, counter, hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    value = struct.unpack(">I", digest[offset:offset + 4])[0] & 0x7FFFFFFF
+    return str(value % (10 ** digits)).zfill(digits)
+
+
+def provisioning_uri(secret: str, *, account: str, issuer: str = "ROMarr") -> str:
+    """The `otpauth://` URI an authenticator scans."""
+    label = quote(f"{issuer}:{account}", safe="")
+    return (f"otpauth://totp/{label}?secret={secret}"
+            f"&issuer={quote(issuer, safe='')}&algorithm=SHA1"
+            f"&digits={DIGITS}&period={STEP_SECONDS}")
+
+
+def backup_codes(count: int = 10) -> list[str]:
+    """Single-use codes for when the phone is gone.
+
+    Grouped with a hyphen because they get written down, and a wall of
+    undifferentiated hex is transcribed wrong.
+    """
+    out = set()
+    while len(out) < count:
+        raw = secrets.token_hex(5).upper()
+        out.add(f"{raw[:5]}-{raw[5:]}")
+    return sorted(out)
+
+
+def _pad(secret: str) -> str:
+    text = str(secret or "").strip().replace(" ", "").upper()
+    return text + "=" * (-len(text) % 8)
+
+
+def _normalise(code) -> str:
+    """A code as typed: people add spaces, and backup codes carry hyphens."""
+    return "".join(str(code or "").split()).replace("-", "").upper()
+
+
+class Totp:
+    """One user's second factor."""
+
+    def __init__(self, secret: str = "", backup=None,
+                 step: int = STEP_SECONDS, drift: int = DRIFT_STEPS):
+        self.secret = str(secret or "")
+        self.backup = list(backup or [])
+        self.step = step
+        self.drift = drift
+        #: The last counter accepted, so a code cannot be used twice. Held in
+        #: memory: a restart is a far smaller window than the 30 seconds this
+        #: closes, and persisting it would mean a write on every login.
+        self._used: int | None = None
+
+    @property
+    def enabled(self) -> bool:
+        """No secret means two-factor is *off*, not open."""
+        return bool(self.secret)
+
+    def verify(self, code) -> bool:
+        if not self.enabled:
+            return False
+        candidate = _normalise(code)
+        if not candidate:
+            return False
+
+        # Backup codes first: they are not six digits, so they can never
+        # collide with a real one, and checking them here means a spent code
+        # is rejected rather than falling through to the TOTP comparison.
+        for index, stored in enumerate(self.backup):
+            if hmac.compare_digest(_normalise(stored), candidate):
+                self.backup.pop(index)
+                return True
+
+        now = int(time.time())
+        for offset in range(-self.drift, self.drift + 1):
+            moment = now + offset * self.step
+            counter = moment // self.step
+            expected = code_at(self.secret, moment, step=self.step)
+            if hmac.compare_digest(expected, candidate):
+                if self._used is not None and counter <= self._used:
+                    # Already spent. A code stays valid for its whole step
+                    # plus the drift window, which is long enough for anyone
+                    # who saw it to reuse it.
+                    return False
+                self._used = counter
+                return True
+        return False

--- a/romarr/upgrade.py
+++ b/romarr/upgrade.py
@@ -1,0 +1,210 @@
+"""Manual import, tags, and deciding whether a new release is an upgrade.
+
+The last of the *arr surface, and the upgrade rule is the one worth arguing
+about.
+
+Radarr upgrades on a quality ladder: 1080p beats 720p, and the ladder is a
+matter of taste. ROMs have no such ladder -- a dump is byte-identical to the
+published cartridge or it is not -- so "better" here means something stronger
+and much less arguable:
+
+    an unverified file is upgraded by a verified one.
+
+That is not a preference, it is a fact about the bytes, and it makes ROMarr's
+upgrade the only one in this class of tool that cannot be wrong.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .dat import BAD_DUMP, UNKNOWN, VERIFIED
+
+log = logging.getLogger(__name__)
+
+
+# --- upgrades ---------------------------------------------------------------
+
+#: How much better each verification state is than the one below it.
+#:
+#: A bad dump ranks *below* unknown deliberately. Unknown means "no DAT knows
+#: this", which is the normal state of homebrew and translations; bad-dump
+#: means "a DAT knows what this should be and this is not it". Ranking them
+#: equal would let a corrupt file sit forever next to a perfectly good
+#: unrecognised one, with nothing ever replacing it.
+VERDICT_RANK = {BAD_DUMP: 0, UNKNOWN: 1, VERIFIED: 2}
+
+
+@dataclass(frozen=True)
+class UpgradeDecision:
+    upgrade: bool
+    reason: str = ""
+
+
+def is_upgrade(current_verdict: str, candidate_verdict: str, *,
+               current_size: int = 0, candidate_size: int = 0,
+               allow_sidegrade: bool = False) -> UpgradeDecision:
+    """Whether a candidate should replace what is already in the library.
+
+    Verification first, because it is the only comparison here that is a fact
+    rather than a preference. Size is a tie-breaker and only with
+    `allow_sidegrade`, since re-downloading a byte-identical game because the
+    new copy is 3 KB larger is churn, not an upgrade.
+    """
+    current = VERDICT_RANK.get(current_verdict, VERDICT_RANK[UNKNOWN])
+    candidate = VERDICT_RANK.get(candidate_verdict, VERDICT_RANK[UNKNOWN])
+
+    if candidate > current:
+        return UpgradeDecision(
+            True, f"{candidate_verdict} beats {current_verdict}")
+    if candidate < current:
+        return UpgradeDecision(
+            False, f"{candidate_verdict} is worse than {current_verdict}")
+
+    if not allow_sidegrade:
+        return UpgradeDecision(
+            False, f"both are {current_verdict}; no upgrade")
+    if candidate_size > current_size:
+        return UpgradeDecision(
+            True, f"same verdict, larger dump ({candidate_size} > {current_size})")
+    return UpgradeDecision(False, "same verdict, not larger")
+
+
+# --- tags -------------------------------------------------------------------
+
+#: A tag is a label a person types, so it is normalised rather than trusted:
+#: "Favourites", "favourites " and "FAVOURITES" are one tag, and treating them
+#: as three produces a filter list nobody can use.
+_TAG_CLEAN = re.compile(r"[^a-z0-9 _-]+")
+
+
+def normalise_tag(tag: str) -> str:
+    cleaned = _TAG_CLEAN.sub("", str(tag or "").strip().lower())
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def merge_tags(existing, adding=None, removing=None) -> list[str]:
+    """The resulting tag set, normalised, deduplicated and ordered.
+
+    Sorted rather than insertion-ordered because tags are rendered as a row of
+    chips and a set that reorders itself on every edit is unreadable.
+    """
+    out = {normalise_tag(t) for t in (existing or []) if normalise_tag(t)}
+    out |= {normalise_tag(t) for t in (adding or []) if normalise_tag(t)}
+    out -= {normalise_tag(t) for t in (removing or []) if normalise_tag(t)}
+    return sorted(out)
+
+
+def matches_tags(item_tags, required) -> bool:
+    """Whether an item carries every required tag."""
+    have = {normalise_tag(t) for t in (item_tags or [])}
+    return all(normalise_tag(t) in have for t in (required or []))
+
+
+# --- manual import ----------------------------------------------------------
+
+@dataclass
+class Candidate:
+    """One file a scan found, and what ROMarr thinks it is."""
+
+    path: str
+    filename: str
+    size: int = 0
+    platform: str = ""
+    reason: str = ""
+    verdict: str = UNKNOWN
+    game: str = ""
+
+
+@dataclass
+class ScanResult:
+    candidates: list[Candidate] = field(default_factory=list)
+    skipped: int = 0
+    error: str = ""
+
+
+#: Never offered for import. Nothing here is a ROM, and listing them makes an
+#: operator read past twenty rows of noise to find the four that matter.
+_IGNORE_SUFFIXES = (
+    ".nfo", ".txt", ".diz", ".sfv", ".jpg", ".jpeg", ".png", ".gif",
+    ".url", ".md5", ".sha1", ".par2", ".exe", ".bat", ".db", ".ini",
+    ".xml", ".dat", ".log", ".srm", ".state", ".sav",
+)
+
+
+def scan(directory, platforms, dats=None, *, limit: int = 2000) -> ScanResult:
+    """Find importable files under a directory.
+
+    Radarr calls this Manual Import and it exists for the same reason here:
+    an operator arrives with a library already on disk, and telling them to
+    re-download everything ROMarr could have adopted is absurd.
+
+    The platform is guessed from the extension and the *parent directory
+    name*, in that order. Extension alone is not enough -- `.bin` is Mega
+    Drive, Atari 2600 and a PlayStation track, and `.iso` is five systems --
+    so a file sitting in a folder called `psx` is taken at its word.
+    """
+    root = Path(directory)
+    if not root.is_dir():
+        return ScanResult(error=f"{root} is not a directory")
+
+    by_extension: dict[str, list] = {}
+    by_slug = {}
+    for platform in platforms:
+        by_slug[platform.slug.lower()] = platform
+        for extension in platform.extensions:
+            by_extension.setdefault(extension.lower(), []).append(platform)
+
+    result = ScanResult()
+    for path in sorted(root.rglob("*")):
+        if len(result.candidates) >= limit:
+            break
+        if not path.is_file():
+            continue
+        suffix = path.suffix.lower()
+        if suffix in _IGNORE_SUFFIXES:
+            result.skipped += 1
+            continue
+
+        # The parent directory wins when it names a platform: it is a
+        # deliberate statement by whoever laid the library out, and an
+        # extension shared by five systems is not.
+        parent = by_slug.get(path.parent.name.lower())
+        options = by_extension.get(suffix) or []
+        if parent is not None and (not options or parent in options):
+            platform, reason = parent, f"in a folder named {path.parent.name!r}"
+        elif len(options) == 1:
+            platform, reason = options[0], f"{suffix} is unique to it"
+        elif options:
+            platform = options[0]
+            reason = (f"{suffix} is used by "
+                      f"{', '.join(p.slug for p in options)} -- confirm before "
+                      "importing")
+        else:
+            result.skipped += 1
+            continue
+
+        candidate = Candidate(
+            path=str(path), filename=path.name,
+            size=path.stat().st_size,
+            platform=platform.slug, reason=reason,
+        )
+        if dats is not None:
+            from .dat import hash_file
+
+            try:
+                match = dats.lookup(**hash_file(path))
+                candidate.verdict = match.status
+                candidate.game = match.game
+                # A DAT match is a stronger statement than either guess above,
+                # and it names the actual game rather than the file.
+                if match.status == VERIFIED and match.game:
+                    candidate.reason = f"verified in a DAT as {match.game}"
+            except OSError as exc:
+                log.warning("could not hash %s: %s", path, exc)
+        result.candidates.append(candidate)
+
+    return result

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -161,6 +161,12 @@ def test_every_verb_is_guarded_so_a_crash_is_a_500_not_a_dead_socket():
     curl reports 000 -- so there is nothing to search for and no way to tell a
     crash from a network problem. A search that exceeded Prowlarr's 60s timeout
     did exactly this.
+
+    Every verb now goes through `_gate`, which authenticates and then hands
+    off to `_guard` -- so the rule this pins is unchanged, but it is one layer
+    further out. Both links are asserted, because a `_gate` that stopped
+    calling `_guard` would restore the dead socket without failing anything
+    else.
     """
     import io as _io
     import pathlib
@@ -168,8 +174,9 @@ def test_every_verb_is_guarded_so_a_crash_is_a_500_not_a_dead_socket():
                    encoding="utf-8").read()
     for verb, inner in (("do_GET", "_get"), ("do_POST", "_post"),
                         ("do_PUT", "_put"), ("do_DELETE", "_delete")):
-        assert f"def {verb}(self):\n            return self._guard(self.{inner})" in src, verb
+        assert f"def {verb}(self):\n            return self._gate(self.{inner})" in src, verb
     assert "def _guard(self, handler):" in src
+    assert "return self._guard(handler)" in src, "_gate must still guard"
 
 
 def test_an_unresolvable_platform_is_reported_rather_than_silently_ignored(tmp_path):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,155 @@
+"""Nobody who is not you gets to queue a download.
+
+ROMarr had no authentication of any kind. `_guard` is an exception handler,
+not a gate, so every endpoint -- including the ones that grab a torrent, write
+to the library, and rewrite settings -- answered anybody who could reach the
+port. On a LAN that is one curl from a guest network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr.auth import Auth, new_api_key
+
+
+def test_a_generated_key_is_long_enough_to_be_worth_generating():
+    key = new_api_key()
+    assert len(key) >= 32
+    assert key != new_api_key()
+
+
+def test_the_right_key_is_accepted_and_a_wrong_one_is_not():
+    auth = Auth(api_key="s3cret")
+    assert auth.check_key("s3cret")
+    assert not auth.check_key("s3cre")
+    assert not auth.check_key("s3crett")
+    assert not auth.check_key("")
+    assert not auth.check_key(None)
+
+
+def test_an_empty_configured_key_never_authorises():
+    """A blank key must not turn into "anything matches".
+
+    `hmac.compare_digest("", "")` is True, so a config that lost its key would
+    otherwise authorise every request that sent no key at all -- an outage
+    that fails open.
+    """
+    auth = Auth(api_key="")
+    assert not auth.check_key("")
+    assert not auth.check_key("anything")
+    assert not auth.authorised(headers={}, query={}, cookies={})
+
+
+# --- how a request presents itself ----------------------------------------
+
+def test_the_header_is_accepted():
+    auth = Auth(api_key="k")
+    assert auth.authorised(headers={"X-Api-Key": "k"}, query={}, cookies={})
+
+
+def test_the_header_is_case_insensitive():
+    """HTTP header names are case-insensitive and real clients differ."""
+    auth = Auth(api_key="k")
+    for name in ("X-Api-Key", "x-api-key", "X-API-KEY"):
+        assert auth.authorised(headers={name: "k"}, query={}, cookies={}), name
+
+
+def test_a_bearer_token_is_accepted():
+    auth = Auth(api_key="k")
+    assert auth.authorised(headers={"Authorization": "Bearer k"}, query={},
+                           cookies={})
+
+
+def test_the_query_string_is_accepted_because_some_senders_cannot_set_headers():
+    """The inbound request webhook is the case.
+
+    A front-end that posts a notification may not let you add a header, and
+    refusing it would mean either no auth on the one endpoint that queues
+    downloads, or no integration at all.
+    """
+    auth = Auth(api_key="k")
+    assert auth.authorised(headers={}, query={"apikey": ["k"]}, cookies={})
+
+
+def test_a_wrong_key_anywhere_is_still_refused():
+    auth = Auth(api_key="k")
+    assert not auth.authorised(headers={"X-Api-Key": "nope"}, query={}, cookies={})
+    assert not auth.authorised(headers={}, query={"apikey": ["nope"]}, cookies={})
+    assert not auth.authorised(headers={}, query={}, cookies={"romarr_session": "nope"})
+
+
+# --- sessions, so a browser does not hold the key in every request --------
+
+def test_a_session_issued_here_is_accepted_here():
+    auth = Auth(api_key="k")
+    token = auth.issue_session()
+    assert auth.authorised(headers={}, query={}, cookies={"romarr_session": token})
+
+
+def test_a_session_from_another_install_is_not_accepted():
+    """The token is signed with the API key, so it cannot travel."""
+    token = Auth(api_key="one").issue_session()
+    assert not Auth(api_key="two").authorised(
+        headers={}, query={}, cookies={"romarr_session": token})
+
+
+def test_a_tampered_session_is_refused():
+    auth = Auth(api_key="k")
+    token = auth.issue_session()
+    body, _, signature = token.rpartition(".")
+    assert not auth.check_session(f"{body}x.{signature}")
+    assert not auth.check_session(f"{body}.{signature}x")
+    assert not auth.check_session(body)
+
+
+def test_a_session_expires():
+    auth = Auth(api_key="k", session_seconds=-1)
+    assert not auth.check_session(auth.issue_session())
+
+
+# --- passwords -------------------------------------------------------------
+
+def test_a_password_is_not_stored_in_the_clear():
+    auth = Auth(api_key="k")
+    stored = auth.hash_password("hunter2")
+    assert "hunter2" not in stored
+    assert stored.count("$") >= 2, "salt and digest must both be recorded"
+
+
+def test_the_right_password_is_accepted():
+    auth = Auth(api_key="k")
+    auth.password_hash = auth.hash_password("hunter2")
+    assert auth.check_password("hunter2")
+    assert not auth.check_password("hunter3")
+    assert not auth.check_password("")
+
+
+def test_no_password_configured_means_password_login_is_off_not_open():
+    auth = Auth(api_key="k")
+    assert not auth.check_password("")
+    assert not auth.check_password("anything")
+
+
+def test_the_same_password_hashes_differently_each_time():
+    auth = Auth(api_key="k")
+    assert auth.hash_password("x") != auth.hash_password("x"), "salt it"
+
+
+# --- the escape hatch ------------------------------------------------------
+
+def test_auth_can_be_turned_off_deliberately():
+    """For an install already behind an authenticating reverse proxy.
+
+    Real, and this operator runs one. Making them keep a second credential
+    in front of a proxy that already checked identity is friction with no
+    security gain -- but it has to be a deliberate setting, never a default
+    and never something a missing key falls back to.
+    """
+    auth = Auth(api_key="k", enabled=False)
+    assert auth.authorised(headers={}, query={}, cookies={})
+
+
+def test_off_is_only_ever_explicit():
+    assert Auth(api_key="k").enabled
+    assert Auth(api_key="").enabled, "a missing key must not disable the gate"

--- a/tests/test_auth_http.py
+++ b/tests/test_auth_http.py
@@ -302,3 +302,91 @@ def test_login_requires_the_second_factor_when_one_is_enrolled(tmp_path):
         assert "romarr_session=" in headers.get("Set-Cookie", "")
     finally:
         httpd.shutdown(); httpd.server_close()
+
+
+# --- ops endpoints, as a request meets them --------------------------------
+
+def test_metrics_needs_a_key_like_everything_else(server):
+    """A metrics endpoint open while the rest of the app is not is a hole
+    with a Grafana dashboard attached: it names every dependency, the queue
+    depth and the library size."""
+    base, _ = server
+    assert get(base + "/metrics")[0] == 401
+
+    code, body, _ = get(base + "/metrics", key="testkey")
+    assert code == 200
+    assert b"romarr_up 1" in body
+    assert b"# TYPE romarr_platforms gauge" in body
+
+
+def test_backup_omits_credentials_by_default(server):
+    base, service = server
+    service.store.settings["download_clients"] = [
+        {"name": "q", "type": "qbittorrent", "password": "hunter2"}]
+    _, body, _ = get(base + "/api/v1/backup", key="testkey")
+    assert b"hunter2" not in body
+    assert json.loads(body)["kind"] == "romarr-backup"
+
+
+def test_backup_can_include_credentials_when_asked(server):
+    base, service = server
+    service.store.settings["download_clients"] = [
+        {"name": "q", "type": "qbittorrent", "password": "hunter2"}]
+    _, body, _ = get(base + "/api/v1/backup?secrets=1", key="testkey")
+    assert b"hunter2" in body
+
+
+def test_restore_rejects_something_that_is_not_a_backup(server):
+    base, _ = server
+    code, _, _ = get(base + "/api/v1/restore", key="testkey", method="POST",
+                     body={"kind": "not-a-backup"})
+    assert code == 400
+
+
+def test_restore_round_trips_a_backup(server):
+    base, service = server
+    service.store.settings["min_seeders"] = 7
+    _, backup, _ = get(base + "/api/v1/backup", key="testkey")
+    service.store.settings["min_seeders"] = 1
+
+    code, body, _ = get(base + "/api/v1/restore", key="testkey", method="POST",
+                        body=json.loads(backup))
+    assert code == 200
+    assert service.store.settings["min_seeders"] == 7
+    assert "password" in json.loads(body)["warning"].lower()
+
+
+def test_export_offers_csv(server):
+    base, _ = server
+    code, body, headers = get(base + "/api/v1/export?what=wanted&format=csv",
+                              key="testkey")
+    assert code == 200
+    assert "text/csv" in headers.get("Content-Type", "")
+
+
+def test_an_unknown_export_is_refused(server):
+    base, _ = server
+    assert get(base + "/api/v1/export?what=nonsense", key="testkey")[0] == 400
+
+
+def test_login_is_rate_limited(tmp_path):
+    """The one endpoint where guessing is the attack, so it has to be limited
+    for callers who have not authenticated -- which is all of them there."""
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "k"})
+    base, httpd = _serve(service)
+    try:
+        codes = [get(base + "/api/v1/login", method="POST",
+                     body={"apikey": "wrong"})[0] for _ in range(12)]
+        assert 429 in codes, codes
+        limited = get(base + "/api/v1/login", method="POST",
+                      body={"apikey": "wrong"})
+        assert limited[2].get("Retry-After")
+    finally:
+        httpd.shutdown(); httpd.server_close()
+
+
+def test_ordinary_browsing_is_not_rate_limited(server):
+    base, _ = server
+    codes = [get(base + "/api/v1/game", key="testkey")[0] for _ in range(20)]
+    assert set(codes) == {200}

--- a/tests/test_auth_http.py
+++ b/tests/test_auth_http.py
@@ -1,0 +1,194 @@
+"""The gate as a request actually meets it.
+
+The unit tests prove `Auth` decides correctly. These prove the decision is
+*applied* -- against a real socket, because a gate that is right in isolation
+and unwired is exactly as open as no gate at all.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+import pytest
+
+from romarr.app import ROMarr, make_handler
+
+
+@pytest.fixture
+def server(tmp_path):
+    """A live ROMarr on a loopback port, with auth on and a known key."""
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "testkey"})
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(service))
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_address[1]}", service
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def get(url, key=None, cookie=None, method="GET", body=None):
+    request = urllib.request.Request(url, method=method)
+    if key:
+        request.add_header("X-Api-Key", key)
+    if cookie:
+        request.add_header("Cookie", cookie)
+    if body is not None:
+        request.add_header("Content-Type", "application/json")
+        request.data = json.dumps(body).encode()
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return response.status, response.read(), response.headers
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), exc.headers
+
+
+# --- the gate holds --------------------------------------------------------
+
+@pytest.mark.parametrize("path", [
+    "/api/v1/game",
+    "/api/v1/queue",
+    "/api/v1/config",
+    "/api/v1/system/status",
+    "/api/platforms",
+    "/api/queue",
+])
+def test_reading_anything_needs_a_key(server, path):
+    base, _ = server
+    code, _, _ = get(base + path)
+    assert code == 401, f"{path} answered {code} with no key"
+
+
+@pytest.mark.parametrize("path", [
+    "/api/v1/game",
+    "/api/v1/system/status",
+    "/api/platforms",
+])
+def test_the_key_opens_it(server, path):
+    base, _ = server
+    code, _, _ = get(base + path, key="testkey")
+    assert code == 200, path
+
+
+def test_a_wrong_key_is_refused(server):
+    base, _ = server
+    code, _, _ = get(base + "/api/v1/game", key="wrong")
+    assert code == 401
+
+
+def test_writing_needs_a_key(server):
+    """The endpoints that matter most: these queue downloads and rewrite
+    settings, and they were the ones answering anybody."""
+    base, _ = server
+    for method, path, body in [
+        ("POST", "/api/v1/webhook", {"data": {"game_title": "x",
+                                              "platforms": ["snes"]}}),
+        ("PUT", "/api/v1/config", {"min_seeders": 5}),
+    ]:
+        code, _, _ = get(base + path, method=method, body=body)
+        assert code == 401, f"{method} {path} answered {code}"
+
+
+def test_a_401_says_how_to_authenticate(server):
+    base, _ = server
+    _, body, _ = get(base + "/api/v1/game")
+    assert b"X-Api-Key" in body
+
+
+# --- what stays open, and how little it says -------------------------------
+
+def test_the_healthcheck_still_works_without_a_key(server):
+    """The container HEALTHCHECK has no credential and must not need one."""
+    base, _ = server
+    code, body, _ = get(base + "/api/health")
+    assert code == 200
+    assert json.loads(body)["ok"] is True
+
+
+def test_an_unauthenticated_healthcheck_gives_away_nothing(server):
+    """It used to return library paths, client URLs and counts. A liveness
+    probe needs one bit; anything more is free reconnaissance."""
+    base, _ = server
+    _, body, _ = get(base + "/api/health")
+    payload = json.loads(body)
+    assert set(payload) == {"ok"}
+
+
+def test_an_authenticated_healthcheck_is_still_the_full_report(server):
+    base, _ = server
+    _, body, _ = get(base + "/api/health", key="testkey")
+    payload = json.loads(body)
+    assert "libraries" in payload and "platforms" in payload
+
+
+def test_the_ui_shell_is_served_so_there_is_somewhere_to_log_in(server):
+    base, _ = server
+    code, body, _ = get(base + "/")
+    assert code == 200 and b"<" in body
+
+
+# --- logging in ------------------------------------------------------------
+
+def test_the_key_can_be_exchanged_for_a_session(server):
+    base, _ = server
+    code, _, headers = get(base + "/api/v1/login", method="POST",
+                           body={"apikey": "testkey"})
+    assert code == 200
+    cookie = headers.get("Set-Cookie", "")
+    assert "romarr_session=" in cookie
+    assert "HttpOnly" in cookie
+    assert "SameSite" in cookie
+
+    session = cookie.split(";")[0]
+    code, _, _ = get(base + "/api/v1/game", cookie=session)
+    assert code == 200, "the session it just issued must work"
+
+
+def test_a_bad_login_is_refused_and_sets_no_cookie(server):
+    base, _ = server
+    code, _, headers = get(base + "/api/v1/login", method="POST",
+                           body={"apikey": "wrong"})
+    assert code == 401
+    assert "romarr_session=" not in headers.get("Set-Cookie", "")
+
+
+# --- the escape hatch, end to end ------------------------------------------
+
+def test_auth_disabled_opens_everything_deliberately(tmp_path):
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_AUTH": "disabled"})
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(service))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    try:
+        assert get(base + "/api/v1/game")[0] == 200
+        assert set(json.loads(get(base + "/api/health")[1])) != {"ok"}
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_a_key_is_generated_when_none_is_configured(tmp_path):
+    """Secure by default. An install that is open until somebody reads the
+    documentation is an install that is open."""
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json")})
+    assert service.auth.enabled
+    assert len(service.auth.api_key) >= 32
+
+
+def test_the_generated_key_survives_a_restart(tmp_path):
+    data = str(tmp_path / "s.json")
+    first = ROMarr({"ROMARR_DATA": data}).auth.api_key
+    second = ROMarr({"ROMARR_DATA": data}).auth.api_key
+    assert first == second and first
+
+
+def test_the_key_is_never_returned_by_the_config_endpoint(server):
+    """It is a credential, and that endpoint feeds a browser page."""
+    base, service = server
+    _, body, _ = get(base + "/api/v1/config", key="testkey")
+    assert b"testkey" not in body

--- a/tests/test_auth_http.py
+++ b/tests/test_auth_http.py
@@ -192,3 +192,113 @@ def test_the_key_is_never_returned_by_the_config_endpoint(server):
     base, service = server
     _, body, _ = get(base + "/api/v1/config", key="testkey")
     assert b"testkey" not in body
+
+
+# --- single sign-on, as a request meets it ---------------------------------
+
+def _serve(service):
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(service))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return f"http://127.0.0.1:{httpd.server_address[1]}", httpd
+
+
+def test_sso_accepts_an_identity_from_a_trusted_proxy(tmp_path):
+    """127.0.0.1 is the peer for a loopback test, so trusting it here is the
+    same arrangement an operator has with a proxy on the LAN."""
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "k",
+                      "ROMARR_AUTH": "forward",
+                      "ROMARR_TRUSTED_PROXIES": "127.0.0.1/32"})
+    base, httpd = _serve(service)
+    try:
+        request = urllib.request.Request(base + "/api/v1/game")
+        request.add_header("X-authentik-username", "wade")
+        with urllib.request.urlopen(request, timeout=10) as response:
+            assert response.status == 200
+    finally:
+        httpd.shutdown(); httpd.server_close()
+
+
+def test_the_identity_header_alone_is_not_a_login(tmp_path):
+    """The bypass this exists to close: with the peer outside every trusted
+    range, `curl -H 'X-authentik-username: admin'` must be worth nothing."""
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "k",
+                      "ROMARR_AUTH": "forward",
+                      # Loopback is deliberately NOT trusted here, so the
+                      # test's own connection is an untrusted peer.
+                      "ROMARR_TRUSTED_PROXIES": "10.99.99.0/24"})
+    base, httpd = _serve(service)
+    try:
+        code, _, _ = get(base + "/api/v1/game")
+        assert code == 401
+        request = urllib.request.Request(base + "/api/v1/game")
+        request.add_header("X-authentik-username", "admin")
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                assert False, f"header alone was accepted: {response.status}"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 401
+    finally:
+        httpd.shutdown(); httpd.server_close()
+
+
+def test_the_api_key_still_works_alongside_sso(tmp_path):
+    """A script cannot go through the browser's SSO flow, so the key has to
+    keep working or every automation breaks the day SSO is turned on."""
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "k",
+                      "ROMARR_AUTH": "forward",
+                      "ROMARR_TRUSTED_PROXIES": "10.99.99.0/24"})
+    base, httpd = _serve(service)
+    try:
+        assert get(base + "/api/v1/game", key="k")[0] == 200
+    finally:
+        httpd.shutdown(); httpd.server_close()
+
+
+def test_a_required_group_is_enforced_over_http(tmp_path):
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "k",
+                      "ROMARR_AUTH": "forward",
+                      "ROMARR_TRUSTED_PROXIES": "127.0.0.1/32",
+                      "ROMARR_SSO_GROUP": "romarr-admins"})
+    base, httpd = _serve(service)
+    try:
+        for groups, expected in (("users|romarr-admins", 200), ("users", 401)):
+            request = urllib.request.Request(base + "/api/v1/game")
+            request.add_header("X-authentik-username", "wade")
+            request.add_header("X-authentik-groups", groups)
+            try:
+                with urllib.request.urlopen(request, timeout=10) as response:
+                    assert response.status == expected, groups
+            except urllib.error.HTTPError as exc:
+                assert exc.code == expected, groups
+    finally:
+        httpd.shutdown(); httpd.server_close()
+
+
+def test_login_requires_the_second_factor_when_one_is_enrolled(tmp_path):
+    from romarr.totp import code_at, new_secret
+    import time as _time
+
+    secret = new_secret()
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json"),
+                      "ROMARR_API_KEY": "k"})
+    service.auth.password_hash = service.auth.hash_password("hunter2")
+    service.auth.totp.secret = secret
+    base, httpd = _serve(service)
+    try:
+        # Right password, no code.
+        code, _, _ = get(base + "/api/v1/login", method="POST",
+                         body={"password": "hunter2"})
+        assert code == 401
+
+        # Right password, right code.
+        code, _, headers = get(base + "/api/v1/login", method="POST",
+                               body={"password": "hunter2",
+                                     "totp": code_at(secret, int(_time.time()))})
+        assert code == 200
+        assert "romarr_session=" in headers.get("Set-Cookie", "")
+    finally:
+        httpd.shutdown(); httpd.server_close()

--- a/tests/test_brand.py
+++ b/tests/test_brand.py
@@ -131,3 +131,34 @@ def test_the_brand_is_not_split_apart_by_a_flex_gap():
     assert gap, "#brand should state its gap explicitly, so this cannot regress"
     assert gap.group(1).strip() in ("0", "0px"), \
         f"a flex gap of {gap.group(1)!r} splits the brand into two words"
+
+
+def test_contrib_carries_the_brand_correctly():
+    """The plugins ship to other people's machines under this name.
+
+    The sweep covered the Python package and the docs but not `contrib/`, so
+    the LaunchBox plugin went out with a `Romarr` namespace and PowerShell
+    functions called `Invoke-RomarrSync` -- user-visible in Playnite's own
+    menu. Extending the guard here is what makes that a test failure rather
+    than something noticed in a screenshot.
+    """
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "contrib"
+    if not root.is_dir():
+        return
+
+    # `romarr` lower-case is legitimate: package paths, the config filename,
+    # a hostname in an example URL. What is wrong is the title-case spelling,
+    # which is neither the brand nor an identifier convention here.
+    wrong = re.compile(r"\bRomarr\b")
+    offenders = []
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() in (".png", ".jpg", ".ico"):
+            continue
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            if wrong.search(line):
+                offenders.append(f"{path.name}:{number}: {line.strip()}")
+    assert not offenders, "brand is ROMarr:\n" + "\n".join(offenders)

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -1,0 +1,215 @@
+"""Searching the plugin catalogue, installing your own, submitting one."""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+
+import pytest
+
+from romarr.catalogue import (
+    DEFAULT_ALLOWED_HOSTS, Submission, check_source, facets, search,
+    submission_link)
+
+ITEMS = [
+    {"slug": "nointro-archive", "name": "No-Intro Archive",
+     "author": "blizz", "description": "Cartridge dumps from Archive.org",
+     "capabilities": ["search", "importer"], "platforms": ["snes", "nes"],
+     "installed": True},
+    {"slug": "redump-mirror", "name": "Redump Mirror", "author": "someone",
+     "description": "Disc images", "capabilities": ["search"],
+     "platforms": ["psx"], "installed": False},
+    {"slug": "cover-art", "name": "Cover Art", "author": "blizz",
+     "description": "Box art and screenshots for the archive",
+     "capabilities": ["metadata"], "platforms": [], "installed": False},
+]
+
+
+# --- search ----------------------------------------------------------------
+
+def test_an_exact_slug_wins():
+    """What somebody typing `redump-mirror` meant. Burying it under fuzzy
+    name matches makes search feel broken even though it worked."""
+    assert search(ITEMS, "redump-mirror")[0]["slug"] == "redump-mirror"
+
+
+def test_a_partial_slug_matches_before_a_description():
+    got = search(ITEMS, "archive")
+    assert got[0]["slug"] == "nointro-archive", [g["slug"] for g in got]
+    assert any(g["slug"] == "cover-art" for g in got), "description still counts"
+
+
+def test_search_matches_the_author():
+    assert {g["slug"] for g in search(ITEMS, "blizz")} == {"nointro-archive",
+                                                          "cover-art"}
+
+
+def test_search_is_case_insensitive():
+    assert search(ITEMS, "REDUMP")[0]["slug"] == "redump-mirror"
+
+
+def test_an_empty_query_returns_everything():
+    assert len(search(ITEMS, "")) == len(ITEMS)
+
+
+def test_nothing_matching_returns_nothing_rather_than_everything():
+    assert search(ITEMS, "zzzz") == []
+
+
+def test_filtering_by_capability():
+    got = search(ITEMS, capability="search")
+    assert {g["slug"] for g in got} == {"nointro-archive", "redump-mirror"}
+
+
+def test_filtering_by_platform():
+    assert [g["slug"] for g in search(ITEMS, platform="psx")] == ["redump-mirror"]
+
+
+def test_filtering_by_installed_state():
+    assert [g["slug"] for g in search(ITEMS, installed=True)] == ["nointro-archive"]
+    assert len(search(ITEMS, installed=False)) == 2
+
+
+def test_filters_combine_with_the_query():
+    assert search(ITEMS, "archive", capability="metadata")[0]["slug"] == "cover-art"
+
+
+# --- facets ----------------------------------------------------------------
+
+def test_facets_are_built_from_what_is_actually_there():
+    """Not a hardcoded list, so a new capability appears in the filter menu
+    the moment a plugin declares one."""
+    got = facets(ITEMS)
+    assert ("search", 2) in got["capabilities"]
+    assert ("metadata", 1) in got["capabilities"]
+    assert ("snes", 1) in got["platforms"]
+
+
+def test_facets_of_an_empty_catalogue_are_empty_not_an_error():
+    assert facets([]) == {"capabilities": [], "platforms": []}
+
+
+# --- install your own ------------------------------------------------------
+
+def test_a_known_forge_over_https_is_allowed():
+    for host in DEFAULT_ALLOWED_HOSTS:
+        assert check_source(f"https://{host}/me/my-plugin").ok, host
+
+
+def test_plain_http_is_refused():
+    """Not pedantry: http means anybody on the network path chooses what code
+    ROMarr executes."""
+    got = check_source("http://github.com/me/my-plugin")
+    assert not got.ok
+    assert "https" in got.reason
+
+
+def test_an_unknown_host_is_refused_and_says_which_are_allowed():
+    """A plugin is code ROMarr runs. "Install from any URL" is remote code
+    execution with a text box in front of it."""
+    got = check_source("https://evil.example/me/plugin")
+    assert not got.ok
+    assert "evil.example" in got.reason
+    assert "github.com" in got.reason
+
+
+def test_a_self_hosted_forge_can_be_allowed_deliberately():
+    assert check_source("https://git.moveweight.com/me/plugin",
+                        allowed_hosts=["git.moveweight.com"]).ok
+
+
+def test_a_bare_host_is_not_a_repository():
+    assert not check_source("https://github.com").ok
+    assert not check_source("https://github.com/").ok
+
+
+@pytest.mark.parametrize("url", ["", None, "not a url", "ftp://github.com/a/b",
+                                 "javascript:alert(1)"])
+def test_junk_is_refused(url):
+    assert not check_source(url).ok
+
+
+# --- submission ------------------------------------------------------------
+
+def good_submission(**kw):
+    return Submission(**{
+        "slug": "my-plugin", "name": "My Plugin",
+        "repository": "https://github.com/me/my-plugin",
+        "author": "me", "description": "Does a thing",
+        "capabilities": ["search"], "platforms": ["snes"], **kw})
+
+
+def test_a_complete_submission_has_no_problems():
+    assert good_submission().problems() == []
+
+
+def test_every_problem_is_reported_at_once():
+    """A form that reveals one error per attempt takes five round trips, and
+    each one is a chance to give up."""
+    problems = Submission().problems()
+    assert len(problems) >= 4
+    assert any("slug" in p for p in problems)
+    assert any("description" in p for p in problems)
+    assert any("capability" in p for p in problems)
+
+
+@pytest.mark.parametrize("slug", ["Bad Slug", "UPPER", "trailing-", "-leading",
+                                  "double--hyphen", "with_underscore", ""])
+def test_a_bad_slug_is_rejected(slug):
+    """It becomes a directory name and a CLI argument, so it is validated
+    rather than trusted."""
+    assert any("slug" in p for p in good_submission(slug=slug).problems())
+
+
+def test_a_submission_with_no_capability_is_rejected():
+    assert any("capability" in p
+               for p in good_submission(capabilities=[]).problems())
+
+
+def test_a_submission_from_an_unknown_host_is_rejected():
+    problems = good_submission(repository="https://evil.example/a/b").problems()
+    assert any("repository" in p for p in problems)
+
+
+# --- the link, which ROMarr prepares and never follows ---------------------
+
+def test_the_link_is_a_prefilled_issue():
+    link = submission_link(good_submission())
+    assert link.startswith("https://github.com/BlizzHacker/rom-hub/issues/new?")
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(link).query)
+    assert "my-plugin" in query["title"][0]
+    assert "plugin-submission" in query["labels"][0]
+
+
+def test_the_link_carries_the_entry_as_valid_json():
+    """Whoever reviews it should be able to paste it into the catalogue rather
+    than retype it from prose."""
+    link = submission_link(good_submission())
+    body = urllib.parse.parse_qs(urllib.parse.urlsplit(link).query)["body"][0]
+    block = body.split("```json")[1].split("```")[0]
+    entry = json.loads(block)
+    assert entry["slug"] == "my-plugin"
+    assert entry["capabilities"] == ["search"]
+
+
+def test_the_link_escapes_a_description_that_would_break_the_url():
+    link = submission_link(good_submission(
+        description="Has & ampersands, #hashes and a\nnewline"))
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(link).query)
+    assert "ampersands" in query["body"][0]
+    assert "newline" in query["body"][0]
+
+
+def test_submitting_sends_nothing():
+    """ROMarr prepares the submission and hands back a link. Publishing under
+    somebody's name is their decision, and a tool that posts because they
+    clicked a button in a settings page has made it for them -- it also means
+    this works with no token configured, which is the normal case.
+    """
+    import inspect
+
+    from romarr import catalogue
+
+    source = inspect.getsource(catalogue)
+    for outbound in ("requests.post", "urlopen", "http.client", "session.post"):
+        assert outbound not in source, f"catalogue must not send: {outbound}"

--- a/tests/test_dat.py
+++ b/tests/test_dat.py
@@ -1,0 +1,285 @@
+"""Proving an import is the right file, which no other *arr can do.
+
+Radarr cannot tell you whether the file it imported is correct. There is no
+canonical hash for a movie, so its last mile is "something arrived, it is
+probably fine". Every game manager that scores filenames -- gamarr included --
+is making the same guess with better vocabulary.
+
+ROMs are the exception: No-Intro and Redump publish the CRC32, MD5 and SHA1 of
+every correct dump that exists. So the question "is this the right file" has an
+answer, and these tests are that answer.
+"""
+
+from __future__ import annotations
+
+import zlib
+
+import pytest
+
+from romarr.dat import (
+    DatIndex, Match, VERIFIED, BAD_DUMP, UNKNOWN, header_bytes, parse_dat,
+    hash_bytes)
+
+# A Logiqx DAT, the format both No-Intro and Redump publish.
+NOINTRO = """<?xml version="1.0"?>
+<datafile>
+  <header>
+    <name>Nintendo - Super Nintendo Entertainment System</name>
+    <version>20260101-000000</version>
+  </header>
+  <game name="Super Metroid (USA)">
+    <description>Super Metroid (USA)</description>
+    <rom name="Super Metroid (USA).sfc" size="3145728"
+         crc="D63ED5F8" md5="21f3e98df4780ee1c667b84e57d88675"
+         sha1="da957f0d63d14cb441d215462904d982ec45a7ca"/>
+  </game>
+  <game name="Super Metroid (Europe)" cloneof="Super Metroid (USA)">
+    <description>Super Metroid (Europe)</description>
+    <rom name="Super Metroid (Europe).sfc" size="3145728" crc="AAAAAAAA"/>
+  </game>
+  <game name="Super Metroid (Japan)" cloneof="Super Metroid (USA)">
+    <description>Super Metroid (Japan)</description>
+    <rom name="Super Metroid (Japan).sfc" size="3145728" crc="BBBBBBBB"/>
+  </game>
+  <game name="Chrono Trigger (USA)">
+    <rom name="Chrono Trigger (USA).sfc" size="4194304" crc="2D206BF7"/>
+  </game>
+</datafile>"""
+
+# Redump lists every track of a disc as its own <rom>, which is why a cue+bin
+# set has to verify per track rather than as one file.
+REDUMP = """<?xml version="1.0"?>
+<datafile>
+  <header><name>Sony - PlayStation</name></header>
+  <game name="Silent Hill (USA)">
+    <rom name="Silent Hill (USA).cue" size="123" crc="11111111"/>
+    <rom name="Silent Hill (USA) (Track 1).bin" size="600000" crc="22222222"/>
+    <rom name="Silent Hill (USA) (Track 2).bin" size="300000" crc="33333333"/>
+  </game>
+</datafile>"""
+
+
+@pytest.fixture
+def snes():
+    return parse_dat(NOINTRO)
+
+
+@pytest.fixture
+def psx():
+    return parse_dat(REDUMP)
+
+
+# --- parsing ---------------------------------------------------------------
+
+def test_a_dat_knows_what_it_is(snes):
+    assert snes.name.startswith("Nintendo - Super Nintendo")
+    assert snes.version == "20260101-000000"
+
+
+def test_every_game_is_indexed(snes):
+    assert len(snes.games) == 4
+
+
+def test_a_rom_carries_every_hash_the_dat_published(snes):
+    rom = snes.games["Super Metroid (USA)"].roms[0]
+    assert rom.size == 3145728
+    assert rom.crc == "d63ed5f8", "normalised to lower case for comparison"
+    assert rom.md5 == "21f3e98df4780ee1c667b84e57d88675"
+    assert rom.sha1.startswith("da957f0d")
+
+
+def test_a_disc_game_has_a_rom_per_track(psx):
+    game = psx.games["Silent Hill (USA)"]
+    assert len(game.roms) == 3
+    assert [r.name.rsplit(".", 1)[1] for r in game.roms] == ["cue", "bin", "bin"]
+
+
+def test_junk_is_not_an_exception():
+    assert parse_dat("<not xml").games == {}
+    assert parse_dat("").games == {}
+
+
+# --- lookup ----------------------------------------------------------------
+
+def test_a_known_crc_is_verified(snes):
+    got = snes.lookup(crc="d63ed5f8", size=3145728)
+    assert got.status == VERIFIED
+    assert got.game == "Super Metroid (USA)"
+    assert got.rom.name == "Super Metroid (USA).sfc"
+
+
+def test_crc_matching_is_case_insensitive(snes):
+    assert snes.lookup(crc="D63ED5F8", size=3145728).status == VERIFIED
+
+
+def test_an_unknown_crc_is_unknown_not_bad(snes):
+    """Absence from a DAT is not proof of a bad dump.
+
+    A homebrew title, a translation, a brand-new release, or simply an older
+    DAT all produce a hash the file does not contain. Calling that "bad" would
+    have ROMarr rejecting perfectly good files with total confidence.
+    """
+    got = snes.lookup(crc="ffffffff", size=999)
+    assert got.status == UNKNOWN
+    assert got.game == ""
+
+
+def test_a_right_size_wrong_hash_is_a_bad_dump(snes):
+    """This is the case worth catching. A file the exact size of a known ROM
+    whose contents do not match is a corrupt or tampered dump -- not something
+    unknown, something wrong."""
+    got = snes.lookup(crc="deadbeef", size=3145728)
+    assert got.status == BAD_DUMP
+    assert "Super Metroid" in got.detail or "3145728" in got.detail
+
+
+def test_sha1_wins_over_crc_when_both_are_available(snes):
+    """CRC32 is 32 bits and collides. Where the DAT published a SHA1 and the
+    caller computed one, that is the answer."""
+    got = snes.lookup(crc="00000000", sha1="da957f0d63d14cb441d215462904d982ec45a7ca")
+    assert got.status == VERIFIED
+    assert got.game == "Super Metroid (USA)"
+
+
+def test_lookup_with_nothing_to_go_on_is_unknown(snes):
+    assert snes.lookup().status == UNKNOWN
+
+
+# --- the copier-header trap ------------------------------------------------
+#
+# The single reason naive implementations of this never match anything.
+
+@pytest.mark.parametrize("suffix,size", [
+    (".nes", 16),      # iNES
+    (".fds", 16),      # fwNES
+    (".lnx", 64),      # Lynx
+    (".a78", 128),     # Atari 7800
+])
+def test_the_known_headers_are_declared(suffix, size):
+    assert header_bytes(suffix, b"\x00" * 4096) == size
+
+
+def test_an_smc_header_is_detected_by_size_not_by_extension():
+    """A .smc may or may not carry a 512-byte copier header -- the extension
+    does not say. The rule the whole preservation world uses is arithmetic:
+    a headered dump is 512 bytes more than a multiple of 32KB.
+    """
+    assert header_bytes(".smc", b"\x00" * (32768 + 512)) == 512
+    assert header_bytes(".smc", b"\x00" * 32768) == 0
+
+
+def test_a_headered_rom_still_verifies(snes):
+    """The trap, end to end.
+
+    No-Intro hashes are headerless. A headered file hashed as-is produces a
+    CRC that appears in no DAT ever published, so every single NES and SNES
+    import would come back "unknown" and the feature would look useless
+    rather than broken.
+    """
+    body = b"\xA5" * 3145728
+    headered = b"\x00" * 512 + body
+    crc = f"{zlib.crc32(body) & 0xFFFFFFFF:08x}"
+    dat = parse_dat(NOINTRO.replace("D63ED5F8", crc.upper()))
+
+    computed = hash_bytes(headered, suffix=".smc")
+    assert computed["size"] == 3145728, "the header is excluded from the size too"
+    assert dat.lookup(**computed).status == VERIFIED
+
+
+def test_a_headerless_rom_is_unaffected():
+    body = b"\x5A" * 4096
+    plain = hash_bytes(body, suffix=".sfc")
+    assert plain["size"] == 4096
+    assert plain["crc"] == f"{zlib.crc32(body) & 0xFFFFFFFF:08x}"
+
+
+def test_hashing_reports_every_algorithm_the_dats_use():
+    got = hash_bytes(b"abc", suffix=".bin")
+    assert set(got) >= {"crc", "md5", "sha1", "size"}
+
+
+# --- 1G1R: one game, one ROM ----------------------------------------------
+
+def test_clones_resolve_to_their_parent(snes):
+    assert snes.parent_of("Super Metroid (Europe)") == "Super Metroid (USA)"
+    assert snes.parent_of("Super Metroid (USA)") == "Super Metroid (USA)"
+
+
+def test_one_game_one_rom_keeps_the_preferred_region(snes):
+    """Igir's headline feature, and the reason a 10,000-entry set collapses to
+    a playable 3,000. The regional ladder is the scorer's, so a 1G1R set and a
+    grab of the same game agree about which dump is wanted."""
+    kept = snes.one_game_one_rom(["USA", "Europe", "Japan"])
+    assert "Super Metroid (USA)" in kept
+    assert "Super Metroid (Europe)" not in kept
+    assert "Super Metroid (Japan)" not in kept
+    assert "Chrono Trigger (USA)" in kept, "a game with no clones survives"
+
+
+def test_one_game_one_rom_falls_back_when_the_preference_is_absent(snes):
+    """A game that exists only as a Japanese dump must not vanish because the
+    operator prefers USA -- dropping it silently is how a "cleaned" set loses
+    titles nobody notices for months."""
+    kept = snes.one_game_one_rom(["Brazil"])
+    assert len(kept) == 2, kept
+
+
+# --- the shape callers depend on ------------------------------------------
+
+def test_a_match_is_readable(snes):
+    got = snes.lookup(crc="d63ed5f8", size=3145728)
+    assert "Super Metroid (USA)" in str(got)
+    assert isinstance(got, Match)
+
+
+def test_an_index_merges_several_dats():
+    """An operator has one DAT per system. Verification has to consult all of
+    them without the caller knowing which one a file belongs to."""
+    index = DatIndex()
+    index.add(parse_dat(NOINTRO))
+    index.add(parse_dat(REDUMP))
+    assert index.lookup(crc="d63ed5f8", size=3145728).status == VERIFIED
+    assert index.lookup(crc="22222222", size=600000).status == VERIFIED
+    assert index.lookup(crc="0badf00d", size=7).status == UNKNOWN
+    assert len(index.dats) == 2
+
+
+def test_an_empty_index_answers_unknown_rather_than_raising():
+    """An operator with no DATs loaded is the common case on day one, and it
+    must not turn every import into an error."""
+    assert DatIndex().lookup(crc="d63ed5f8").status == UNKNOWN
+
+
+# --- hashing a real file, which is what an import actually does ------------
+
+def test_hash_file_agrees_with_hash_bytes(tmp_path):
+    body = b"\x37" * 100_000
+    path = tmp_path / "Game (USA).sfc"
+    path.write_bytes(body)
+    from romarr.dat import hash_file
+    assert hash_file(path) == hash_bytes(body, suffix=".sfc")
+
+
+def test_hash_file_strips_a_header_the_same_way(tmp_path):
+    body = b"\xA5" * (32768 * 4)
+    path = tmp_path / "Game (USA).smc"
+    path.write_bytes(b"\x00" * 512 + body)
+    from romarr.dat import hash_file
+    got = hash_file(path)
+    assert got["size"] == len(body)
+    assert got["crc"] == hash_bytes(body, suffix=".sfc")["crc"]
+
+
+def test_hash_file_never_buffers_the_whole_file(tmp_path):
+    """The header probe used to build a buffer the size of the file to decide
+    whether 512 bytes should be skipped -- four gigabytes for a PS2 image,
+    reintroducing the exact problem chunked hashing exists to avoid.
+
+    Asserted by reading in tiny chunks: a correct implementation seeks past
+    the header and streams, so chunk size cannot change the answer.
+    """
+    body = b"\x11" * 300_000
+    path = tmp_path / "Big (USA).iso"
+    path.write_bytes(body)
+    from romarr.dat import hash_file
+    assert hash_file(path, chunk=997) == hash_file(path, chunk=1024 * 1024)

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1,0 +1,163 @@
+"""Exporting to LaunchBox, Playnite and ES-DE.
+
+The plugins in `contrib/` are .NET and PowerShell and cannot be compiled or
+run here. This module is what they consume, it is pure functions over library
+rows, and it is therefore the part that can actually be proven -- which is why
+the integration is built on it rather than on the plugins.
+"""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from romarr.frontends import (
+    FORMATS, esde_folder, launchbox_platform, to_gamelist, to_launchbox,
+    to_playnite)
+from romarr.platforms import PLATFORMS
+
+ROWS = [
+    {"id": "1", "title": "Super Metroid", "platform": "snes",
+     "path": "/roms/snes/Super Metroid (USA).sfc",
+     "filename": "Super Metroid (USA).sfc", "verified": "verified"},
+    {"id": "2", "title": "Silent Hill", "platform": "psx",
+     "path": "/roms/psx/Silent Hill (USA).chd",
+     "filename": "Silent Hill (USA).chd"},
+]
+
+
+# --- platform naming, which is the whole difficulty ------------------------
+
+def test_launchbox_gets_the_names_it_recognises():
+    """LaunchBox matches metadata by platform NAME. A name it does not know
+    imports with no box art, no description and no association with the rest
+    of that system -- it looks like the export half-worked, which is harder to
+    diagnose than a clean failure."""
+    assert launchbox_platform("snes") == "Super Nintendo Entertainment System"
+    assert launchbox_platform("psx") == "Sony Playstation"
+    assert launchbox_platform("genesis-slash-megadrive") == "Sega Genesis"
+
+
+def test_an_unmapped_platform_falls_back_to_its_slug():
+    """Better a tile named `weird-slug` than no tile."""
+    assert launchbox_platform("weird-slug") == "weird-slug"
+
+
+def test_esde_gets_its_own_folder_names():
+    assert esde_folder("genesis-slash-megadrive") == "megadrive"
+    assert esde_folder("turbografx16--1") == "tg16"
+    assert esde_folder("snes") == "snes"
+
+
+def test_most_platforms_have_a_launchbox_name():
+    """A slug with no mapping still exports, but silently loses its metadata,
+    so the coverage is worth pinning rather than discovering later."""
+    named = sum(1 for p in PLATFORMS if p.slug in
+                __import__("romarr.frontends", fromlist=["x"]).LAUNCHBOX_PLATFORMS)
+    assert named >= len(PLATFORMS) - 5, f"only {named}/{len(PLATFORMS)} mapped"
+
+
+# --- LaunchBox -------------------------------------------------------------
+
+def test_launchbox_export_is_valid_xml_with_the_expected_shape():
+    root = ET.fromstring(to_launchbox(ROWS))
+    assert root.tag == "LaunchBox"
+    games = root.findall("Game")
+    assert len(games) == 2
+    assert games[0].findtext("Title") == "Super Metroid"
+    assert games[0].findtext("ApplicationPath").endswith("Super Metroid (USA).sfc")
+    assert games[0].findtext("Platform") == "Super Nintendo Entertainment System"
+
+
+def test_a_row_with_no_path_is_skipped_not_written_broken():
+    """ApplicationPath is what LaunchBox launches. A dead tile is worse than a
+    missing one -- it looks like a working library until somebody clicks it."""
+    root = ET.fromstring(to_launchbox([{"title": "No file", "platform": "snes"}]))
+    assert root.findall("Game") == []
+
+
+def test_the_dat_verdict_survives_into_notes():
+    """LaunchBox has no field for it and it is the most useful thing in the
+    row, so it goes somewhere a person will read rather than being dropped."""
+    root = ET.fromstring(to_launchbox(ROWS))
+    assert "verified" in root.findall("Game")[0].findtext("Notes")
+
+
+def test_a_title_with_xml_special_characters_survives():
+    """`Ratchet & Clank` and `<untitled>` break hand-written XML and are
+    exactly the titles a real library contains."""
+    rows = [{"title": "Ratchet & Clank: <Up> \"Arsenal\"", "platform": "ps2",
+             "path": "/roms/ps2/r.iso"}]
+    root = ET.fromstring(to_launchbox(rows))
+    assert root.findall("Game")[0].findtext("Title") == rows[0]["title"]
+
+
+# --- ES-DE -----------------------------------------------------------------
+
+def test_gamelist_is_valid_and_uses_relative_paths():
+    """EmulationStation expects `./name`, and a relative path is what lets a
+    gamelist survive the ROM directory being mounted somewhere else -- the
+    normal case when the files live on a NAS and the frontend is a handheld."""
+    root = ET.fromstring(to_gamelist(ROWS))
+    assert root.tag == "gameList"
+    paths = [g.findtext("path") for g in root.findall("game")]
+    assert paths == ["./Super Metroid (USA).sfc", "./Silent Hill (USA).chd"]
+
+
+def test_gamelist_falls_back_to_the_filename_for_a_name():
+    root = ET.fromstring(to_gamelist([{"filename": "Game.sfc"}]))
+    assert root.findall("game")[0].findtext("name") == "Game.sfc"
+
+
+def test_gamelist_skips_a_row_with_nothing_to_point_at():
+    assert ET.fromstring(to_gamelist([{"title": "Nothing"}])).findall("game") == []
+
+
+# --- Playnite --------------------------------------------------------------
+
+def test_playnite_export_is_flat_json_a_script_can_read():
+    """The consumer is PowerShell. Anything needing a schema to interpret is a
+    script that breaks the first time a field is absent."""
+    payload = json.loads(to_playnite(ROWS))
+    assert payload["source"] == "ROMarr"
+    assert len(payload["games"]) == 2
+    game = payload["games"][0]
+    assert set(game) == {"name", "platform", "romPath", "id", "verified"}
+    assert game["platform"] == "Super Nintendo Entertainment System"
+
+
+def test_playnite_export_omits_rows_with_no_file():
+    payload = json.loads(to_playnite([{"title": "No file", "platform": "snes"}]))
+    assert payload["games"] == []
+
+
+def test_every_playnite_field_is_a_string_even_when_absent():
+    """A missing key and a null both break `$game.verified` in PowerShell in
+    ways that are hard to read in a log."""
+    payload = json.loads(to_playnite(ROWS))
+    for game in payload["games"]:
+        assert all(isinstance(v, str) for v in game.values())
+
+
+# --- the registry ----------------------------------------------------------
+
+@pytest.mark.parametrize("name", sorted(FORMATS))
+def test_every_format_renders_and_declares_itself(name):
+    spec = FORMATS[name]
+    assert spec["label"] and spec["filename"] and spec["content_type"]
+    out = spec["render"](ROWS)
+    assert isinstance(out, str) and out.strip()
+
+
+@pytest.mark.parametrize("name", sorted(FORMATS))
+def test_every_format_survives_an_empty_library(name):
+    """Day one, and the moment a filter matches nothing. Neither should
+    produce a file the launcher refuses to open."""
+    out = FORMATS[name]["render"]([])
+    assert out.strip()
+    if "xml" in FORMATS[name]["content_type"]:
+        ET.fromstring(out)
+    else:
+        json.loads(out)

--- a/tests/test_indexer_drivers.py
+++ b/tests/test_indexer_drivers.py
@@ -1,0 +1,218 @@
+"""Every way ROMarr can be pointed at an indexer, not just Prowlarr.
+
+Radarr's Add Indexer dialog offers Newznab, Torznab and a handful of direct
+trackers. ROMarr offered Prowlarr, Torznab and Newznab, which meant an
+operator running Jackett had to know that Jackett speaks Torznab and hand-build
+the `/api/v2.0/indexers/all/results/torznab/` URL themselves -- and an operator
+running Bitmagnet or NZBHydra2 had nothing telling them it would work at all.
+
+Four of the products below are Torznab or Newznab underneath. That is the
+point: they are definitions over two protocol clients, not six new clients.
+Two -- a plain RSS feed and TorrentPotato -- genuinely are different, and get
+their own parsers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr import indexers
+from romarr.indexers import (
+    INDEXER_TYPES, TorrentPotato, TorrentPotatoConfig, TorrentRss,
+    TorrentRssConfig, build_indexer, driver_for)
+
+
+# --- the registry ----------------------------------------------------------
+
+EXPECTED = ("prowlarr", "jackett", "nzbhydra2", "cardigann", "bitmagnet",
+            "torznab", "newznab", "torrentrss", "torrentpotato")
+
+
+@pytest.mark.parametrize("kind", EXPECTED)
+def test_every_advertised_indexer_type_exists(kind):
+    assert kind in INDEXER_TYPES, kind
+
+
+@pytest.mark.parametrize("kind", EXPECTED)
+def test_every_type_declares_a_driver_and_a_protocol(kind):
+    spec = INDEXER_TYPES[kind]
+    assert spec.get("driver") in ("prowlarr", "torznab", "rss", "potato"), kind
+    assert spec.get("protocol") in ("torrent", "usenet", "any"), kind
+    assert spec.get("label"), kind
+    assert spec.get("fields"), kind
+
+
+@pytest.mark.parametrize("kind", EXPECTED)
+def test_every_type_can_be_redacted_without_leaking_a_secret(kind):
+    """A new type whose secret field is not declared would put a live API key
+    into the settings page."""
+    cfg = {"type": kind, "name": "x", "api_key": "SECRET", "url": "http://h"}
+    out = indexers.redact_indexer(cfg)
+    assert "SECRET" not in str(out), kind
+
+
+# --- the Torznab family ----------------------------------------------------
+
+@pytest.mark.parametrize("kind,protocol", [
+    ("jackett", "torrent"),
+    ("cardigann", "torrent"),
+    ("bitmagnet", "torrent"),
+    ("nzbhydra2", "usenet"),
+    ("torznab", "torrent"),
+    ("newznab", "usenet"),
+])
+def test_the_torznab_family_builds_a_working_client(kind, protocol):
+    client = build_indexer({"type": kind, "url": "http://host/api",
+                            "api_key": "k", "name": kind})
+    assert client is not None, kind
+    assert client._config.protocol == protocol, kind
+
+
+def test_prowlarr_is_still_driven_separately():
+    """It aggregates many indexers rather than being one, so the service holds
+    it apart. build_indexer returning a client for it would search it twice."""
+    assert build_indexer({"type": "prowlarr", "url": "http://h", "api_key": "k"}) is None
+
+
+def test_an_indexer_with_no_url_builds_nothing():
+    assert build_indexer({"type": "jackett", "api_key": "k"}) is None
+
+
+def test_jackett_tells_you_the_url_shape_that_actually_works():
+    """The single most common Jackett misconfiguration is pointing ROMarr at
+    the Jackett homepage. The field help has to carry the real path."""
+    fields = {f["name"]: f for f in INDEXER_TYPES["jackett"]["fields"]}
+    assert "torznab" in fields["url"].get("help", "").lower()
+    assert "9117" in str(fields["url"].get("default", ""))
+
+
+def test_bitmagnet_needs_no_api_key():
+    """It indexes the DHT itself, so there is no third party to authenticate
+    to. Demanding a key would make a working setup look misconfigured."""
+    fields = {f["name"]: f for f in INDEXER_TYPES["bitmagnet"]["fields"]}
+    assert not fields["api_key"].get("required", False)
+    client = build_indexer({"type": "bitmagnet", "url": "http://h:3333/torznab"})
+    assert client is not None
+
+
+def test_nzbhydra2_defaults_to_its_own_port():
+    fields = {f["name"]: f for f in INDEXER_TYPES["nzbhydra2"]["fields"]}
+    assert "5076" in str(fields["url"].get("default", ""))
+
+
+# --- a plain RSS feed ------------------------------------------------------
+
+RSS = """<?xml version="1.0"?><rss version="2.0"><channel>
+<item>
+  <title>Chrono Trigger (USA) [!]</title>
+  <link>magnet:?xt=urn:btih:aaaabbbbccccddddeeeeffff00001111&amp;dn=ct</link>
+  <enclosure url="magnet:?xt=urn:btih:aaaabbbbccccddddeeeeffff00001111"
+             length="3145728" type="application/x-bittorrent"/>
+</item>
+<item>
+  <title>Super Metroid (USA)</title>
+  <link>https://tracker.example/dl/2.torrent</link>
+  <enclosure url="https://tracker.example/dl/2.torrent" length="2097152"
+             type="application/x-bittorrent"/>
+</item>
+</channel></rss>"""
+
+
+def test_an_rss_feed_yields_releases():
+    feed = TorrentRss(TorrentRssConfig(url="http://f/rss", name="Feed"))
+    got = feed.parse(RSS)
+    assert [r.title for r in got] == ["Chrono Trigger (USA) [!]",
+                                      "Super Metroid (USA)"]
+    assert got[0].size == 3145728
+    assert got[0].download_url.startswith("magnet:")
+    assert got[1].download_url.endswith(".torrent")
+
+
+def test_rss_results_carry_a_game_category_so_they_survive_scoring():
+    """`is_game_release` rejects anything without a game category, and a plain
+    RSS feed carries no categories at all -- so every result from one would be
+    thrown away before it was ever scored. The feed is a game feed by
+    configuration; that is what the category asserts."""
+    feed = TorrentRss(TorrentRssConfig(url="http://f/rss", name="Feed"))
+    from romarr.selection import is_game_release
+    assert all(is_game_release(r) for r in feed.parse(RSS))
+
+
+def test_an_rss_feed_marked_private_says_so_on_its_releases():
+    feed = TorrentRss(TorrentRssConfig(url="http://f", name="F", private=True))
+    assert all(r.private for r in feed.parse(RSS))
+
+
+def test_a_malformed_feed_is_empty_not_an_exception():
+    feed = TorrentRss(TorrentRssConfig(url="http://f", name="F"))
+    assert feed.parse("<not xml") == []
+    assert feed.parse("") == []
+
+
+def test_an_rss_item_with_no_usable_link_is_dropped():
+    body = ("<rss><channel><item><title>No link</title></item>"
+            "<item><title>Fine</title><link>magnet:?xt=urn:btih:ab</link>"
+            "</item></channel></rss>")
+    feed = TorrentRss(TorrentRssConfig(url="http://f", name="F"))
+    assert [r.title for r in feed.parse(body)] == ["Fine"]
+
+
+# --- TorrentPotato ---------------------------------------------------------
+
+POTATO = {
+    "results": [
+        {"release_name": "Chrono Trigger (USA)",
+         "download_url": "magnet:?xt=urn:btih:abc",
+         "details_url": "https://t.example/1",
+         "size": 3,                      # TorrentPotato reports MB
+         "seeders": 12, "leechers": 3, "freeleech": True},
+        {"release_name": "Broken", "size": 1},   # no download_url
+    ]
+}
+
+
+def test_torrentpotato_yields_releases():
+    client = TorrentPotato(TorrentPotatoConfig(url="http://p", name="Potato"))
+    got = client.parse(POTATO)
+    assert [r.title for r in got] == ["Chrono Trigger (USA)"]
+    assert got[0].seeders == 12
+
+
+def test_torrentpotato_size_is_megabytes_and_is_converted():
+    """The protocol reports size in MB. Taking it as bytes makes a 3 MB SNES
+    release look like 3 bytes and it is rejected as "too small to be a ROM" --
+    a whole indexer that silently returns nothing usable."""
+    client = TorrentPotato(TorrentPotatoConfig(url="http://p", name="Potato"))
+    assert client.parse(POTATO)[0].size == 3 * 1024 * 1024
+
+
+def test_torrentpotato_survives_junk():
+    client = TorrentPotato(TorrentPotatoConfig(url="http://p", name="Potato"))
+    assert client.parse({}) == []
+    assert client.parse({"results": "nonsense"}) == []
+    assert client.parse(None) == []
+
+
+# --- the driver lookup the service uses ------------------------------------
+
+def test_driver_for_maps_each_type_to_its_family():
+    assert driver_for("jackett") == "torznab"
+    assert driver_for("nzbhydra2") == "torznab"
+    assert driver_for("bitmagnet") == "torznab"
+    assert driver_for("torrentrss") == "rss"
+    assert driver_for("torrentpotato") == "potato"
+    assert driver_for("prowlarr") == "prowlarr"
+    assert driver_for("nonsense") == ""
+
+
+def test_build_indexer_covers_every_non_prowlarr_type():
+    """A type in the registry that build_indexer cannot construct is dead
+    configuration that tests green -- the exact failure the direct-Torznab
+    work was introduced to fix."""
+    for kind, spec in INDEXER_TYPES.items():
+        if spec["driver"] == "prowlarr":
+            continue
+        client = build_indexer({"type": kind, "url": "http://h/api",
+                                "api_key": "k", "name": kind})
+        assert client is not None, f"{kind} is configurable but not searchable"
+        assert hasattr(client, "search") and hasattr(client, "caps"), kind

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -188,3 +188,93 @@ def test_a_provider_with_no_credential_is_skipped_rather_than_failing():
 def test_every_provider_is_declared_completely(name):
     spec = PROVIDERS[name]
     assert spec["label"] and callable(spec["lookup"]) and spec["help"]
+
+
+# --- wired, not merely written --------------------------------------------
+
+def test_the_service_builds_a_metadata_chain(tmp_path):
+    """This test exists because the module shipped unwired.
+
+    249 lines and 27 green tests, and nothing in app.py imported it -- the
+    exact "configuration that tests green and does nothing" failure this
+    project keeps finding elsewhere, committed here. A unit-tested module
+    nobody calls is dead code with a certificate.
+    """
+    from romarr.app import ROMarr
+
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json")})
+    assert hasattr(service, "metadata")
+    assert hasattr(service, "identify")
+
+
+def test_identify_returns_the_shape_the_api_serves(tmp_path):
+    from romarr.app import ROMarr
+
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json")})
+    got = service.identify(filename="Super Metroid (USA) [!].sfc")
+    assert set(got) >= {"found", "title", "cover_url", "matched_by", "source"}
+    assert got["matched_by"] == "filename"
+
+
+def test_adding_a_provider_and_reloading_takes_effect(tmp_path):
+    from romarr.app import ROMarr
+
+    service = ROMarr({"ROMARR_DATA": str(tmp_path / "s.json")})
+    assert service.metadata.providers == []
+    service.store.put_item("metadata_providers",
+                           {"type": "rawg", "api_key": "k", "enable": True})
+    service.reload_metadata()
+    assert len(service.metadata.providers) == 1
+
+
+# --- calendar --------------------------------------------------------------
+
+def test_the_calendar_reports_why_it_is_empty():
+    """"No games" and "you have not configured a provider" look identical in
+    a UI unless one of them says so."""
+    from romarr.metadata import calendar
+
+    got = calendar([])
+    assert got["items"] == []
+    assert "api key" in got["error"].lower()
+
+
+def test_the_calendar_window_looks_backwards_as_well_as_forwards():
+    """"Upcoming" alone is the obvious reading and the less useful one: most
+    of what somebody wants to acquire came out last month."""
+    import datetime
+
+    from romarr.metadata import calendar
+
+    got = calendar([], days_back=30, days_ahead=60)
+    today = datetime.date.today()
+    assert got["from"] < today.isoformat() < got["to"]
+
+
+def test_the_calendar_marks_which_entries_are_still_upcoming(monkeypatch):
+    import datetime
+
+    from romarr import metadata as module
+
+    soon = (datetime.date.today() + datetime.timedelta(days=10)).isoformat()
+    past = (datetime.date.today() - datetime.timedelta(days=10)).isoformat()
+    monkeypatch.setitem(
+        module.CALENDAR_PROVIDERS, "rawg",
+        lambda cfg, start, end, limit: [
+            {"title": "Future Game", "released": soon},
+            {"title": "Past Game", "released": past}])
+
+    rows = module.calendar([{"type": "rawg", "api_key": "k"}])["items"]
+    assert {r["title"]: r["upcoming"] for r in rows} == {
+        "Future Game": True, "Past Game": False}
+
+
+def test_a_calendar_provider_that_raises_does_not_break_the_page(monkeypatch):
+    from romarr import metadata as module
+
+    def boom(cfg, start, end, limit):
+        raise OSError("refused")
+
+    monkeypatch.setitem(module.CALENDAR_PROVIDERS, "rawg", boom)
+    got = module.calendar([{"type": "rawg", "api_key": "k"}])
+    assert got["items"] == [] and got["error"]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,190 @@
+"""Naming a game from a hash rather than a filename.
+
+Every tool in this category parses the release title and hopes. ROMarr knows
+the DAT-verified name exactly, so the lookup key is a fact rather than the
+output of a regular expression. These tests are mostly about that difference.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr.dat import Match
+from romarr.metadata import (
+    PROVIDERS, GameInfo, Metadata, clean_title, lookup_key, title_from_dat)
+
+
+# --- the key, which is the whole idea --------------------------------------
+
+def test_a_verified_file_is_looked_up_by_its_dat_name():
+    """The difference this module exists for.
+
+    `Chrono.Trigger.USA.Retranslated.v1.2.[!].smc` parses to something like
+    "Chrono Trigger Retranslated" -- a search that finds nothing or, worse,
+    finds the wrong thing. The DAT says what it is.
+    """
+    term, how = lookup_key(
+        Match("verified", game="Chrono Trigger (USA)"),
+        "Chrono.Trigger.USA.Retranslated.v1.2.[!].smc")
+    assert term == "Chrono Trigger"
+    assert how == "dat"
+
+
+def test_an_unverified_file_falls_back_to_the_filename():
+    """Still supported, because an unverified file has nothing else -- but it
+    is the fallback, not the method."""
+    term, how = lookup_key(Match("unknown"), "Super Metroid (USA) [!].sfc")
+    assert term == "Super Metroid"
+    assert how == "filename"
+
+
+def test_a_bad_dump_does_not_get_to_claim_the_dat_name():
+    """Its hash did not match, so the DAT's name for it is not established."""
+    _, how = lookup_key(Match("bad-dump"), "Super Metroid (USA).sfc")
+    assert how == "filename"
+
+
+def test_no_verification_at_all_still_works():
+    term, how = lookup_key(None, "Contra (USA).nes")
+    assert term == "Contra" and how == "filename"
+
+
+def test_nothing_to_go_on_yields_nothing():
+    assert lookup_key(None, "") == ("", "")
+
+
+@pytest.mark.parametrize("game,expected", [
+    ("Chrono Trigger (USA)", "Chrono Trigger"),
+    ("Super Metroid (Japan, USA) (En,Ja)", "Super Metroid"),
+    ("Final Fantasy VII (USA) (Disc 1)", "Final Fantasy VII"),
+    ("Sonic the Hedgehog", "Sonic the Hedgehog"),
+    ("", ""),
+])
+def test_a_dat_name_splits_at_the_first_parenthesis(game, expected):
+    """No-Intro and Redump both use `Title (Region) (Extras)`, so the title is
+    exact rather than guessed at."""
+    assert title_from_dat(game) == expected
+
+
+# --- filename parsing, the fallback ---------------------------------------
+
+@pytest.mark.parametrize("filename,expected", [
+    ("Super Metroid (USA) [!].sfc", "Super Metroid"),
+    ("Chrono.Trigger.USA.v1.1.smc", "Chrono Trigger"),
+    ("Sonic_The_Hedgehog_(W)_[!].md", "Sonic The Hedgehog"),
+    ("Final Fantasy VII (USA) (Disc 1).chd", "Final Fantasy VII"),
+    ("Contra (USA) (Rev 1) (Proto).nes", "Contra"),
+    ("Metal Gear Solid [MULTI5].bin", "Metal Gear Solid"),
+])
+def test_filenames_are_cleaned_into_something_searchable(filename, expected):
+    assert clean_title(filename) == expected
+
+
+def test_cleaning_something_that_is_only_decoration_yields_nothing():
+    assert clean_title("(USA) [!].sfc") == ""
+
+
+# --- providers -------------------------------------------------------------
+
+def fake_provider(monkeypatch, result):
+    calls = []
+
+    def lookup(cfg, term):
+        calls.append(term)
+        return result
+
+    monkeypatch.setitem(PROVIDERS, "fake",
+                        {"label": "Fake", "lookup": lookup,
+                         "fields": (), "help": ""})
+    return calls
+
+
+FOUND = GameInfo(title="Chrono Trigger", summary="A JRPG", source="Fake")
+
+
+def test_a_provider_is_asked_with_the_dat_name(monkeypatch):
+    calls = fake_provider(monkeypatch, FOUND)
+    got = Metadata([{"type": "fake"}]).identify(
+        verification=Match("verified", game="Chrono Trigger (USA)"),
+        filename="Chrono.Trigger.USA.Retranslated.smc")
+    assert calls == ["Chrono Trigger"]
+    assert got.title == "Chrono Trigger"
+
+
+def test_the_result_records_how_it_was_matched(monkeypatch):
+    """"we matched a DAT name" and "we guessed from the filename" deserve
+    different amounts of trust, and a UI that shows metadata without saying
+    which is inviting somebody to believe the wrong cover."""
+    fake_provider(monkeypatch, FOUND)
+    metadata = Metadata([{"type": "fake"}])
+    assert metadata.identify(
+        verification=Match("verified", game="Chrono Trigger (USA)")).matched_by == "dat"
+    assert metadata.identify(filename="Contra (USA).nes").matched_by == "filename"
+
+
+def test_providers_are_tried_in_order_until_one_answers(monkeypatch):
+    order = []
+
+    def empty(cfg, term):
+        order.append("empty")
+        return GameInfo()
+
+    def finds(cfg, term):
+        order.append("finds")
+        return FOUND
+
+    monkeypatch.setitem(PROVIDERS, "empty",
+                        {"label": "E", "lookup": empty, "fields": (), "help": ""})
+    monkeypatch.setitem(PROVIDERS, "finds",
+                        {"label": "F", "lookup": finds, "fields": (), "help": ""})
+
+    got = Metadata([{"type": "empty"}, {"type": "finds"}]).identify(
+        filename="Contra.nes")
+    assert order == ["empty", "finds"]
+    assert got.found
+
+
+def test_a_provider_that_raises_does_not_end_the_lookup(monkeypatch):
+    def boom(cfg, term):
+        raise OSError("refused")
+
+    monkeypatch.setitem(PROVIDERS, "boom",
+                        {"label": "B", "lookup": boom, "fields": (), "help": ""})
+    fake_provider(monkeypatch, FOUND)
+    got = Metadata([{"type": "boom"}, {"type": "fake"}]).identify(
+        filename="Contra.nes")
+    assert got.found, "a broken provider must not hide a working one"
+
+
+def test_a_disabled_provider_is_skipped(monkeypatch):
+    calls = fake_provider(monkeypatch, FOUND)
+    Metadata([{"type": "fake", "enable": False}]).identify(filename="Contra.nes")
+    assert calls == []
+
+
+def test_an_unknown_provider_type_is_skipped_not_fatal():
+    assert not Metadata([{"type": "nonsense"}]).identify(
+        filename="Contra.nes").found
+
+
+def test_no_providers_configured_is_not_an_error():
+    """Metadata is an enhancement. A missing cover must never cost an import."""
+    got = Metadata([]).identify(filename="Contra (USA).nes")
+    assert not got.found
+    assert got.matched_by == "filename"
+
+
+def test_a_provider_with_no_credential_is_skipped_rather_than_failing():
+    """RAWG needs a key and IGDB needs two. Unconfigured is the normal state
+    on day one, and it must look like "no metadata yet" rather than an error
+    on every import."""
+    assert not Metadata([{"type": "rawg"}]).identify(
+        filename="Contra.nes").found
+    assert not Metadata([{"type": "igdb"}]).identify(
+        filename="Contra.nes").found
+
+
+@pytest.mark.parametrize("name", sorted(PROVIDERS))
+def test_every_provider_is_declared_completely(name):
+    spec = PROVIDERS[name]
+    assert spec["label"] and callable(spec["lookup"]) and spec["help"]

--- a/tests/test_more_clients.py
+++ b/tests/test_more_clients.py
@@ -1,0 +1,244 @@
+"""Transmission and Deluge, completing the five gamarr has.
+
+Both are small JSON APIs with one famous trap each, and both traps produce the
+same symptom: the client looks configured, Test appears to work or fails
+mysteriously, and no torrent is ever added.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from romarr.downloaders import CLIENT_TYPES, build_client, redact
+
+
+class FakeResponse:
+    def __init__(self, status=200, body=None, headers=None):
+        self.status_code = status
+        self._body = body if body is not None else {}
+        self.headers = headers or {}
+        self.text = json.dumps(self._body) if isinstance(self._body, dict) else str(self._body)
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+            raise requests.HTTPError(response=self)
+
+
+class FakeSession:
+    """Records requests and replays a scripted list of responses."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+        self.cookies = {}
+
+    def post(self, url, **kw):
+        self.calls.append({"url": url, **kw})
+        return self.responses.pop(0) if self.responses else FakeResponse()
+
+    def get(self, url, **kw):
+        self.calls.append({"url": url, **kw})
+        return self.responses.pop(0) if self.responses else FakeResponse()
+
+
+# --- the registry ----------------------------------------------------------
+
+@pytest.mark.parametrize("kind", ["qbittorrent", "transmission", "deluge",
+                                  "sabnzbd", "nzbget"])
+def test_all_five_clients_are_offered(kind):
+    assert kind in CLIENT_TYPES
+
+
+@pytest.mark.parametrize("kind,protocol,port", [
+    ("transmission", "torrent", 9091),
+    ("deluge", "torrent", 8112),
+])
+def test_the_new_clients_declare_the_right_defaults(kind, protocol, port):
+    spec = CLIENT_TYPES[kind]
+    assert spec["protocol"] == protocol
+    assert spec["default_port"] == port
+
+
+@pytest.mark.parametrize("kind", sorted(CLIENT_TYPES))
+def test_no_client_type_leaks_its_secret(kind):
+    out = redact({"type": kind, "password": "SECRET", "api_key": "SECRET"})
+    assert "SECRET" not in str(out), kind
+
+
+@pytest.mark.parametrize("kind", sorted(CLIENT_TYPES))
+def test_every_client_type_can_be_built(kind):
+    client = build_client({"type": kind, "host": "localhost", "port": 1,
+                           "password": "p", "api_key": "k"})
+    assert client is not None, kind
+    assert hasattr(client, "add") and hasattr(client, "reachable"), kind
+
+
+# --- Transmission: the 409 session handshake -------------------------------
+
+def test_transmission_answers_the_409_session_challenge():
+    """THE Transmission trap.
+
+    Every first request is answered 409 with an X-Transmission-Session-Id
+    header, and the call must be repeated carrying it. A client that treats
+    409 as a failure never adds a single torrent and reports the daemon as
+    broken -- which is exactly what it looks like from outside.
+    """
+    from romarr.downloaders import Transmission, TransmissionConfig
+
+    session = FakeSession([
+        FakeResponse(409, {}, {"X-Transmission-Session-Id": "abc123"}),
+        FakeResponse(200, {"result": "success",
+                           "arguments": {"torrent-added": {"id": 1}}}),
+    ])
+    client = Transmission(TransmissionConfig(base_url="http://t:9091"),
+                          session=session)
+
+    assert client.add("magnet:?xt=urn:btih:abc")
+    assert len(session.calls) == 2, "it must retry, not give up"
+    assert session.calls[1]["headers"]["X-Transmission-Session-Id"] == "abc123"
+
+
+def test_transmission_reuses_the_session_id_it_was_given():
+    """Re-challenging on every call doubles every request for no reason."""
+    from romarr.downloaders import Transmission, TransmissionConfig
+
+    session = FakeSession([
+        FakeResponse(409, {}, {"X-Transmission-Session-Id": "abc"}),
+        FakeResponse(200, {"result": "success"}),
+        FakeResponse(200, {"result": "success"}),
+    ])
+    client = Transmission(TransmissionConfig(base_url="http://t:9091"),
+                          session=session)
+    client.add("magnet:?xt=urn:btih:a")
+    client.add("magnet:?xt=urn:btih:b")
+    assert len(session.calls) == 3, "only the first call should be challenged"
+
+
+def test_transmission_posts_to_the_rpc_path():
+    from romarr.downloaders import Transmission, TransmissionConfig
+
+    session = FakeSession([FakeResponse(200, {"result": "success"})])
+    Transmission(TransmissionConfig(base_url="http://t:9091"),
+                 session=session).add("magnet:?xt=urn:btih:a")
+    assert session.calls[0]["url"].endswith("/transmission/rpc")
+    body = json.loads(session.calls[0]["data"])
+    assert body["method"] == "torrent-add"
+    assert body["arguments"]["filename"] == "magnet:?xt=urn:btih:a"
+
+
+def test_transmission_reports_a_non_success_result_as_failure():
+    """Transmission returns HTTP 200 with {"result": "<error text>"}. Reading
+    only the status code calls every rejection a success."""
+    from romarr.downloaders import Transmission, TransmissionConfig
+
+    session = FakeSession([FakeResponse(200, {"result": "invalid or corrupt"})])
+    assert not Transmission(TransmissionConfig(base_url="http://t:9091"),
+                            session=session).add("magnet:?xt=urn:btih:a")
+
+
+def test_transmission_treats_a_duplicate_as_added():
+    """`torrent-duplicate` means it is already there, which is the outcome
+    the caller wanted. Calling it a failure makes a re-run look broken."""
+    from romarr.downloaders import Transmission, TransmissionConfig
+
+    session = FakeSession([FakeResponse(
+        200, {"result": "success", "arguments": {"torrent-duplicate": {"id": 3}}})])
+    assert Transmission(TransmissionConfig(base_url="http://t:9091"),
+                        session=session).add("magnet:?xt=urn:btih:a")
+
+
+# --- Deluge: log in first, and check the daemon is attached ----------------
+
+def test_deluge_logs_in_before_adding():
+    """Deluge's WebUI refuses everything until auth.login succeeds, and it
+    answers an unauthenticated call with a perfectly ordinary-looking JSON
+    error rather than a 401."""
+    from romarr.downloaders import Deluge, DelugeConfig
+
+    session = FakeSession([
+        FakeResponse(200, {"result": True, "error": None}),      # auth.login
+        FakeResponse(200, {"result": True, "error": None}),      # connected
+        FakeResponse(200, {"result": "hash", "error": None}),    # add
+    ])
+    client = Deluge(DelugeConfig(base_url="http://d:8112", password="deluge"),
+                    session=session)
+
+    assert client.add("magnet:?xt=urn:btih:abc")
+    methods = [json.loads(c["data"])["method"] for c in session.calls]
+    assert methods[0] == "auth.login"
+    assert "core.add_torrent_magnet" in methods
+
+
+def test_deluge_refuses_when_the_password_is_wrong():
+    from romarr.downloaders import Deluge, DelugeConfig
+
+    session = FakeSession([FakeResponse(200, {"result": False, "error": None})])
+    assert not Deluge(DelugeConfig(base_url="http://d:8112", password="wrong"),
+                      session=session).add("magnet:?xt=urn:btih:a")
+
+
+def test_deluge_connects_the_webui_to_a_daemon_when_it_is_detached():
+    """The second Deluge trap. The WebUI is a separate process from the
+    daemon, and a freshly started WebUI is attached to nothing -- every call
+    succeeds and no torrent appears anywhere.
+    """
+    from romarr.downloaders import Deluge, DelugeConfig
+
+    session = FakeSession([
+        FakeResponse(200, {"result": True, "error": None}),        # login
+        FakeResponse(200, {"result": False, "error": None}),       # connected? no
+        FakeResponse(200, {"result": [["host1", "127.0.0.1", 58846, "user"]],
+                           "error": None}),                        # get_hosts
+        FakeResponse(200, {"result": True, "error": None}),        # web.connect
+        FakeResponse(200, {"result": "hash", "error": None}),      # add
+    ])
+    client = Deluge(DelugeConfig(base_url="http://d:8112", password="deluge"),
+                    session=session)
+
+    assert client.add("magnet:?xt=urn:btih:a")
+    methods = [json.loads(c["data"])["method"] for c in session.calls]
+    assert "web.connect" in methods
+
+
+def test_deluge_reports_a_json_rpc_error_as_failure():
+    from romarr.downloaders import Deluge, DelugeConfig
+
+    session = FakeSession([
+        FakeResponse(200, {"result": True, "error": None}),
+        FakeResponse(200, {"result": True, "error": None}),
+        FakeResponse(200, {"result": None,
+                           "error": {"message": "Torrent already in session"}}),
+    ])
+    assert not Deluge(DelugeConfig(base_url="http://d:8112", password="p"),
+                      session=session).add("magnet:?xt=urn:btih:a")
+
+
+def test_deluge_sends_the_category_as_a_label():
+    from romarr.downloaders import Deluge, DelugeConfig
+
+    session = FakeSession([
+        FakeResponse(200, {"result": True, "error": None}),
+        FakeResponse(200, {"result": True, "error": None}),
+        FakeResponse(200, {"result": "abc", "error": None}),
+        FakeResponse(200, {"result": None, "error": None}),
+    ])
+    Deluge(DelugeConfig(base_url="http://d:8112", password="p",
+                        category="romarr"), session=session).add("magnet:?x")
+    methods = [json.loads(c["data"])["method"] for c in session.calls]
+    assert any("label" in m for m in methods)
+
+
+# --- both are torrent clients as far as routing is concerned --------------
+
+def test_the_new_clients_are_picked_for_torrents():
+    from romarr.downloaders import pick_client
+
+    transmission = build_client({"type": "transmission", "host": "t"})
+    assert pick_client("torrent", [transmission]) is transmission
+    assert pick_client("usenet", [transmission]) is None

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,211 @@
+"""Notifications, and the one thing they say that others cannot.
+
+Eight providers is a table, not eight clients -- almost every one is an HTTP
+POST with a differently-shaped body. The tests that matter are the ones about
+the *message*: Radarr tells you it grabbed something, and ROMarr can tell you
+what it weighed, because the scorer already explained itself.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from romarr import notify
+from romarr.notify import (
+    NOTIFIERS, Message, Notifier, ON_BAD_DUMP, ON_FAILURE, ON_GRAB, ON_IMPORT,
+    failed, grabbed, imported)
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Capture every outbound request instead of making one."""
+    calls = []
+
+    def fake(url, *, data=None, headers=None, method="POST"):
+        calls.append({"url": url, "data": data, "headers": headers or {},
+                      "method": method})
+        return True
+
+    monkeypatch.setattr(notify, "_post", fake)
+    return calls
+
+
+def conn(kind, **kw):
+    return {"type": kind, "name": kind, "enable": True,
+            "url": f"https://{kind}.test/hook", **kw}
+
+
+# --- every provider is real ------------------------------------------------
+
+@pytest.mark.parametrize("kind", sorted(NOTIFIERS))
+def test_every_provider_sends_something(kind, sent):
+    Notifier([conn(kind, token="t", chat_id="1", user="u")]).send(
+        Message(ON_GRAB, "Chrono Trigger (USA)"))
+    assert len(sent) == 1, f"{kind} sent nothing"
+    assert sent[0]["url"], kind
+
+
+@pytest.mark.parametrize("kind", sorted(NOTIFIERS))
+def test_every_provider_is_declared_completely(kind):
+    spec = NOTIFIERS[kind]
+    assert spec["label"] and callable(spec["send"])
+    assert spec["fields"] and spec["help"]
+
+
+def test_discord_sends_the_rendered_text(sent):
+    Notifier([conn("discord")]).send(
+        Message(ON_GRAB, "Grabbed X", body="SNES", reasons=("+50 good dump",)))
+    payload = json.loads(sent[0]["data"])
+    assert "Grabbed X" in payload["content"]
+    assert "+50 good dump" in payload["content"]
+
+
+def test_a_generic_webhook_gets_structure_not_prose(sent):
+    """Anything consuming this is a program. Handing it a rendered string to
+    parse back into fields is what makes generic webhooks useless."""
+    Notifier([conn("webhook")]).send(
+        Message(ON_GRAB, "Grabbed X", body="SNES", reasons=("+50 a", "-20 b")))
+    payload = json.loads(sent[0]["data"])
+    assert payload["event"] == ON_GRAB
+    assert payload["title"] == "Grabbed X"
+    assert payload["reasons"] == ["+50 a", "-20 b"]
+
+
+def test_ntfy_puts_the_title_in_the_header_where_it_belongs(sent):
+    Notifier([conn("ntfy")]).send(Message(ON_GRAB, "Grabbed X", body="SNES"))
+    assert sent[0]["headers"]["Title"] == "Grabbed X"
+    assert b"SNES" in sent[0]["data"]
+
+
+def test_telegram_targets_the_bot_api_not_the_configured_url(sent):
+    Notifier([{"type": "telegram", "name": "tg", "token": "123:abc",
+               "chat_id": "42"}]).send(Message(ON_GRAB, "X"))
+    assert "api.telegram.org/bot123:abc/sendMessage" in sent[0]["url"]
+    assert json.loads(sent[0]["data"])["chat_id"] == "42"
+
+
+def test_gotify_carries_the_token_in_the_query(sent):
+    Notifier([conn("gotify", token="tok")]).send(Message(ON_GRAB, "X"))
+    assert "token=tok" in sent[0]["url"]
+
+
+# --- event filtering -------------------------------------------------------
+
+def test_a_connection_with_no_event_list_gets_everything():
+    """Somebody who just pasted a Discord webhook wants to be told things."""
+    assert Notifier.wants({"type": "discord"}, ON_GRAB)
+    assert Notifier.wants({"type": "discord"}, ON_FAILURE)
+
+
+def test_an_empty_event_list_means_nothing():
+    """It says exactly what it says. Reading it as "everything" would make
+    muting a connection impossible."""
+    assert not Notifier.wants({"type": "discord", "events": []}, ON_GRAB)
+
+
+def test_only_subscribed_events_are_delivered(sent):
+    notifier = Notifier([conn("discord", events=[ON_FAILURE])])
+    notifier.send(Message(ON_GRAB, "grabbed"))
+    assert sent == []
+    notifier.send(Message(ON_FAILURE, "failed"))
+    assert len(sent) == 1
+
+
+def test_a_disabled_connection_is_skipped(sent):
+    Notifier([conn("discord", enable=False)]).send(Message(ON_GRAB, "X"))
+    assert sent == []
+
+
+# --- failure is never allowed to matter ------------------------------------
+
+def test_a_provider_that_raises_does_not_break_the_send(monkeypatch):
+    def boom(url, **kw):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(notify, "_post", boom)
+    results = Notifier([conn("discord"), conn("slack")]).send(
+        Message(ON_GRAB, "X"))
+    assert [r["ok"] for r in results] == [False, False]
+
+
+def test_one_provider_failing_does_not_stop_the_others(monkeypatch):
+    calls = []
+
+    def flaky(url, **kw):
+        calls.append(url)
+        if "discord" in url:
+            raise OSError("nope")
+        return True
+
+    monkeypatch.setattr(notify, "_post", flaky)
+    results = Notifier([conn("discord"), conn("slack")]).send(
+        Message(ON_GRAB, "X"))
+    assert len(calls) == 2
+    assert [r["ok"] for r in results] == [False, True]
+
+
+def test_an_unknown_provider_type_is_skipped_not_fatal(sent):
+    results = Notifier([{"type": "nonsense", "name": "x"}]).send(
+        Message(ON_GRAB, "X"))
+    assert results == [] and sent == []
+
+
+def test_a_webhook_url_is_not_written_to_the_log_in_full(caplog, monkeypatch):
+    """A Discord or Slack webhook path IS the credential -- anybody holding it
+    can post to that channel. Logging a failure must not leak it."""
+    def boom(url, **kw):
+        raise OSError("refused")
+
+    monkeypatch.setattr(notify.urllib.request, "urlopen", boom)
+    with caplog.at_level("WARNING"):
+        notify._post("https://discord.com/api/webhooks/123/SUPERSECRETTOKEN")
+    assert "SUPERSECRETTOKEN" not in caplog.text
+    assert "discord.com" in caplog.text
+
+
+# --- the message other tools cannot send -----------------------------------
+
+def test_a_grab_notification_carries_the_reasons_it_was_chosen():
+    """The whole point. Radarr says "Grabbed X"; this says what it weighed,
+    which is the difference between trusting the automation and checking it."""
+    message = grabbed("Chrono Trigger (USA) [!]", "Super Nintendo",
+                      "RetroWithin",
+                      ["+50 verified good dump [!]", "+40 region usa"])
+    text = message.text()
+    assert "Chrono Trigger (USA) [!]" in text
+    assert "RetroWithin" in text
+    assert "+50 verified good dump [!]" in text
+    assert "+40 region usa" in text
+
+
+def test_an_import_notification_reports_the_dat_verdict():
+    from romarr.dat import Match
+
+    good = imported("Super Metroid", "SNES",
+                    Match("verified", game="Super Metroid (USA)"))
+    assert good.event == ON_IMPORT
+    assert "verified" in good.text() and "Super Metroid (USA)" in good.text()
+
+
+def test_a_bad_dump_is_its_own_event_so_it_can_be_routed_separately():
+    """Somebody who wants to be paged for a corrupt import and not for every
+    successful one needs these to be different events."""
+    from romarr.dat import Match
+
+    message = imported("X", "SNES", Match("bad-dump", detail="checksum differs"))
+    assert message.event == ON_BAD_DUMP
+    assert "BAD DUMP" in message.text()
+
+
+def test_an_unverified_import_is_still_an_import():
+    from romarr.dat import Match
+
+    message = imported("Homebrew", "SNES", Match("unknown"))
+    assert message.event == ON_IMPORT
+    assert "not in any loaded DAT" in message.text()
+
+
+def test_a_failure_carries_the_reason():
+    assert "no seeders" in failed("X", "no seeders on a public tracker").text()

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,228 @@
+"""Metrics, rate limiting, backup and export.
+
+None of it is clever. All of it is easy to get subtly wrong in a way nobody
+notices until the day it matters, which is what these pin.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from romarr.ops import (
+    DEFAULT_LIMITS, RateLimiter, from_csv, make_backup, read_backup,
+    render_metrics, to_csv)
+
+
+# --- Prometheus ------------------------------------------------------------
+
+def test_metrics_are_valid_exposition_format():
+    text = render_metrics({"platforms": 58, "queued": 2, "uptime_seconds": 90})
+    assert "# HELP romarr_platforms" in text
+    assert "# TYPE romarr_platforms gauge" in text
+    assert "romarr_platforms 58" in text
+    assert text.endswith("\n")
+
+
+def test_every_series_is_declared_exactly_once():
+    """A repeated TYPE line makes Prometheus reject the whole scrape."""
+    text = render_metrics({"dependencies": {"prowlarr": True, "romm": False}})
+    types = [line for line in text.splitlines() if line.startswith("# TYPE")]
+    assert len(types) == len(set(types))
+
+
+def test_dependencies_are_labelled_series():
+    text = render_metrics({"dependencies": {"prowlarr": True, "romm": False}})
+    assert 'romarr_dependency_up{name="prowlarr"} 1' in text
+    assert 'romarr_dependency_up{name="romm"} 0' in text
+
+
+def test_import_verdicts_are_exported_because_nothing_else_can():
+    """The series worth alerting on: a rising bad-dump count means an indexer
+    has started serving corrupt dumps, which nothing else in this category
+    would surface until somebody pressed play."""
+    text = render_metrics({"imports": {"verified": 40, "bad-dump": 3,
+                                       "unknown": 7}})
+    assert 'romarr_imports_total{verdict="bad-dump"} 3' in text
+    assert 'romarr_imports_total{verdict="verified"} 40' in text
+
+
+def test_a_label_value_with_a_quote_is_escaped():
+    """An unescaped quote produces a malformed line and Prometheus drops the
+    entire scrape, not just that series."""
+    text = render_metrics({"dependencies": {'we"ird': True}})
+    assert 'name="we\\"ird"' in text
+
+
+def test_metrics_render_from_an_empty_dict():
+    assert "romarr_up 1" in render_metrics({})
+
+
+# --- rate limiting ---------------------------------------------------------
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+
+def test_requests_under_the_limit_are_allowed():
+    limiter = RateLimiter({"general": (3, 60)}, clock=Clock())
+    assert all(limiter.check("general", "a")[0] for _ in range(3))
+
+
+def test_the_limit_is_enforced():
+    limiter = RateLimiter({"general": (3, 60)}, clock=Clock())
+    for _ in range(3):
+        limiter.check("general", "a")
+    allowed, retry = limiter.check("general", "a")
+    assert not allowed and retry > 0
+
+
+def test_the_window_slides_forward():
+    clock = Clock()
+    limiter = RateLimiter({"general": (2, 60)}, clock=clock)
+    limiter.check("general", "a")
+    limiter.check("general", "a")
+    assert not limiter.check("general", "a")[0]
+    clock.now += 61
+    assert limiter.check("general", "a")[0]
+
+
+def test_one_caller_cannot_lock_out_another():
+    """Keyed on caller as well as category. A shared counter means one noisy
+    script locks the operator out of their own UI -- a denial of service the
+    limiter introduced rather than prevented."""
+    limiter = RateLimiter({"general": (2, 60)}, clock=Clock())
+    limiter.check("general", "noisy")
+    limiter.check("general", "noisy")
+    assert not limiter.check("general", "noisy")[0]
+    assert limiter.check("general", "operator")[0]
+
+
+def test_categories_are_counted_separately():
+    limiter = RateLimiter({"login": (1, 60), "general": (10, 60)},
+                          clock=Clock())
+    limiter.check("login", "a")
+    assert not limiter.check("login", "a")[0]
+    assert limiter.check("general", "a")[0]
+
+
+def test_login_is_the_tightest_limit():
+    """It is the only endpoint where guessing is the attack."""
+    assert DEFAULT_LIMITS["login"][0] < DEFAULT_LIMITS["general"][0]
+    assert DEFAULT_LIMITS["login"][0] <= 10
+
+
+@pytest.mark.parametrize("path,category", [
+    ("/api/v1/login", "login"),
+    ("/api/v1/search?q=x", "search"),
+    ("/api/v1/release", "search"),
+    ("/api/v1/queue", "download"),
+    ("/api/v1/game", "general"),
+])
+def test_paths_are_categorised(path, category):
+    assert RateLimiter.category_for(path) == category
+
+
+def test_an_unknown_category_falls_back_to_general_not_to_unlimited():
+    limiter = RateLimiter({"general": (1, 60)}, clock=Clock())
+    limiter.check("nonsense", "a")
+    assert not limiter.check("nonsense", "a")[0]
+
+
+# --- backup ----------------------------------------------------------------
+
+SETTINGS = {
+    "library_path": "/roms",
+    "min_seeders": 2,
+    "_api_key": "SUPERSECRET",
+    "_totp_secret": "BASE32SECRET",
+    "download_clients": [
+        {"name": "qbit", "type": "qbittorrent", "password": "hunter2"},
+    ],
+    "indexers": [{"name": "ix", "api_key": "IXKEY"}],
+}
+
+
+def test_a_backup_carries_no_credentials_by_default():
+    """A backup gets copied to another machine, emailed to somebody helping,
+    and committed to a private repo "just in case". Every one of those is a
+    place a plaintext qBittorrent password should not be."""
+    body = json.dumps(make_backup(SETTINGS))
+    for secret in ("SUPERSECRET", "hunter2", "IXKEY", "BASE32SECRET"):
+        assert secret not in body, secret
+
+
+def test_a_backup_keeps_everything_that_is_not_a_credential():
+    backup = make_backup(SETTINGS)
+    assert backup["settings"]["library_path"] == "/roms"
+    assert backup["settings"]["min_seeders"] == 2
+    assert backup["settings"]["download_clients"][0]["name"] == "qbit"
+
+
+def test_secrets_are_included_only_when_asked_for():
+    body = json.dumps(make_backup(SETTINGS, include_secrets=True))
+    assert "hunter2" in body
+
+
+def test_a_backup_says_which_kind_it_is():
+    assert make_backup(SETTINGS)["contains_secrets"] is False
+    assert make_backup(SETTINGS, include_secrets=True)["contains_secrets"] is True
+
+
+def test_restoring_warns_that_credentials_are_missing():
+    """Otherwise a restore silently produces an install that cannot log in to
+    anything, and the operator debugs their download client instead."""
+    settings, warning = read_backup(make_backup(SETTINGS))
+    assert settings["library_path"] == "/roms"
+    assert "password" in warning.lower()
+
+
+def test_restoring_a_full_backup_warns_about_nothing():
+    _, warning = read_backup(make_backup(SETTINGS, include_secrets=True))
+    assert warning == ""
+
+
+def test_a_backup_round_trips_through_json():
+    settings, _ = read_backup(json.dumps(make_backup(SETTINGS)))
+    assert settings["min_seeders"] == 2
+
+
+@pytest.mark.parametrize("payload", [
+    "{}", '{"kind": "something-else"}', '{"kind": "romarr-backup"}', "[]",
+])
+def test_restoring_something_that_is_not_a_backup_is_refused(payload):
+    with pytest.raises(ValueError):
+        read_backup(payload)
+
+
+# --- export ----------------------------------------------------------------
+
+def test_csv_survives_a_title_with_a_comma():
+    """Game titles contain commas, quotes and apostrophes. Hand-rolled CSV
+    corrupts exactly those rows and looks correct for everything else."""
+    rows = [{"title": "Ratchet & Clank: Up Your Arsenal, Special", "platform": "ps2"}]
+    text = to_csv(rows)
+    assert from_csv(text)[0]["title"] == rows[0]["title"]
+
+
+def test_csv_survives_quotes_and_newlines():
+    rows = [{"title": 'He said "hi"\nagain', "platform": "snes"}]
+    assert from_csv(to_csv(rows))[0]["title"] == rows[0]["title"]
+
+
+def test_csv_uses_rfc_4180_line_endings():
+    assert to_csv([{"a": "1"}]).endswith("\r\n")
+
+
+def test_csv_columns_are_stable_across_rows_with_different_keys():
+    text = to_csv([{"a": 1}, {"b": 2}])
+    assert text.splitlines()[0] == "a,b"
+
+
+def test_csv_of_nothing_is_still_valid():
+    assert to_csv([], ["title"]).strip() == "title"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,201 @@
+"""Operator policy over the scorer: what to prefer, what to refuse, what to
+never see again.
+
+gamarr has release profiles and a blocklist. Both are flat: a word list, and a
+set of release ids. ROMarr's scorer already explains itself release by release,
+so both of these can be *visible* -- a preferred term shows up in `why()` with
+the points it added, and a blocklist entry carries the reason it was blocked.
+
+That is the difference worth having. "Why did it take that one" and "why will
+it never take this one" are the two questions anybody actually asks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr.platforms import by_slug
+from romarr.profiles import Blocklist, ReleaseProfile, release_id
+from romarr.selection import Release, best_release, judge
+
+SNES = by_slug("snes")
+MB = 1024 * 1024
+
+
+def rel(title, size=3 * MB, seeders=30, url="magnet:?xt=urn:btih:abc"):
+    return Release(title=title, size=size, seeders=seeders,
+                   categories=(1000,), download_url=url, protocol="torrent",
+                   indexer="Test")
+
+
+# --- release profiles ------------------------------------------------------
+
+def test_a_preferred_term_adds_points_and_says_so():
+    profile = ReleaseProfile(preferred=[("[!]", 40)])
+    plain = judge(rel("Super Metroid (USA)"), "super metroid", SNES)
+    good = judge(rel("Super Metroid (USA) [!]"), "super metroid", SNES,
+                 profile=profile)
+    assert good.points > plain.points
+    assert any("[!]" in line for line in good.why())
+
+
+def test_a_negative_preference_subtracts():
+    profile = ReleaseProfile(preferred=[("beta", -50)])
+    verdict = judge(rel("Super Metroid (USA) beta"), "super metroid", SNES,
+                    profile=profile)
+    assert any("-50" in line and "beta" in line for line in verdict.why())
+
+
+def test_an_excluded_term_rejects_outright_and_names_itself():
+    profile = ReleaseProfile(excluded=["proto"])
+    verdict = judge(rel("Super Metroid (USA) proto"), "super metroid", SNES,
+                    profile=profile)
+    assert not verdict.accepted
+    assert "proto" in verdict.verdict
+
+
+def test_a_required_term_rejects_anything_without_it():
+    profile = ReleaseProfile(required=["verified"])
+    assert not judge(rel("Super Metroid (USA)"), "super metroid", SNES,
+                     profile=profile).accepted
+    assert judge(rel("Super Metroid (USA) verified"), "super metroid", SNES,
+                 profile=profile).accepted
+
+
+def test_terms_are_case_insensitive():
+    profile = ReleaseProfile(excluded=["PROTO"])
+    assert not judge(rel("game proto"), "game", SNES, profile=profile).accepted
+
+
+def test_a_regex_term_is_supported_like_radarrs():
+    """Radarr lets a term be a regex, and the cases that need one are real:
+    matching `(Rev 1)` but not `(Rev 10)` cannot be done with a substring."""
+    profile = ReleaseProfile(excluded=[r"/\(Rev \d\)/"])
+    assert not judge(rel("Game (USA) (Rev 1)"), "game", SNES,
+                     profile=profile).accepted
+    assert judge(rel("Game (USA)"), "game", SNES, profile=profile).accepted
+
+
+def test_a_broken_regex_is_ignored_rather_than_crashing_every_search():
+    """An operator typing a bad pattern must not take the search down with
+    it. The term is skipped and logged."""
+    profile = ReleaseProfile(excluded=[r"/[unclosed/"])
+    assert judge(rel("Game (USA)"), "game", SNES, profile=profile).accepted
+
+
+def test_no_profile_leaves_scoring_exactly_as_it_was():
+    release = rel("Super Metroid (USA) [!]")
+    assert (judge(release, "super metroid", SNES).points
+            == judge(release, "super metroid", SNES, profile=ReleaseProfile()).points)
+
+
+def test_a_profile_changes_which_release_wins():
+    """The point of the feature: an operator's preference has to actually move
+    the pick, not merely the score.
+
+    The term is a scene-group name the built-in scorer has no opinion about.
+    Using `[!]` here would prove nothing -- it already earns the good-dump
+    bonus, so it wins with or without a profile.
+    """
+    plain = rel("Chrono Trigger (USA)", seeders=50)
+    tagged = rel("Chrono Trigger (USA) GOLDDISC", seeders=5)
+    assert best_release([plain, tagged], "chrono trigger", SNES) is plain
+    profile = ReleaseProfile(preferred=[("GOLDDISC", 200)])
+    assert best_release([plain, tagged], "chrono trigger", SNES,
+                        profile=profile) is tagged
+
+
+# --- blocklist -------------------------------------------------------------
+
+def test_a_release_has_a_stable_identity():
+    a = rel("Game (USA)")
+    assert release_id(a) == release_id(rel("Game (USA)"))
+    assert release_id(a) != release_id(rel("Game (Europe)"))
+
+
+def test_identity_uses_the_infohash_when_there_is_one():
+    """Titles get rewritten by indexers; an infohash does not. Two results
+    for the same torrent must block as one."""
+    magnet = "magnet:?xt=urn:btih:AABBCCDDEEFF00112233445566778899AABBCCDD&dn=x"
+    same = "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd"
+    assert release_id(rel("One name", url=magnet)) == \
+           release_id(rel("Totally different name", url=same))
+
+
+def test_a_blocked_release_is_rejected_with_the_recorded_reason():
+    """gamarr's blocklist tells you a release is blocked. This tells you why,
+    which is the only form of the answer anybody can act on."""
+    blocked = rel("Game (USA)")
+    blocklist = Blocklist()
+    blocklist.add(blocked, reason="download failed twice: stalled at 0%")
+
+    verdict = judge(blocked, "game", SNES, blocklist=blocklist)
+
+    assert not verdict.accepted
+    assert "stalled at 0%" in verdict.verdict
+
+
+def test_an_unblocked_release_is_untouched():
+    blocklist = Blocklist()
+    blocklist.add(rel("Other (USA)"), reason="x")
+    assert judge(rel("Game (USA)"), "game", SNES, blocklist=blocklist).accepted
+
+
+def test_blocking_survives_a_round_trip_through_storage():
+    blocklist = Blocklist()
+    blocklist.add(rel("Game (USA)"), reason="corrupt")
+    restored = Blocklist.from_items(blocklist.as_items())
+    assert not judge(rel("Game (USA)"), "game", SNES,
+                     blocklist=restored).accepted
+
+
+def test_a_block_records_when_and_what_so_it_can_be_reviewed():
+    blocklist = Blocklist()
+    blocklist.add(rel("Game (USA)"), reason="bad dump")
+    entry = blocklist.as_items()[0]
+    assert entry["title"] == "Game (USA)"
+    assert entry["reason"] == "bad dump"
+    assert entry["blocked_at"] > 0
+    assert entry["indexer"] == "Test"
+
+
+def test_a_block_can_be_lifted():
+    blocklist = Blocklist()
+    blocklist.add(rel("Game (USA)"), reason="x")
+    assert blocklist.remove(release_id(rel("Game (USA)")))
+    assert judge(rel("Game (USA)"), "game", SNES, blocklist=blocklist).accepted
+
+
+def test_lifting_something_that_was_never_blocked_is_not_an_error():
+    assert not Blocklist().remove("nope")
+
+
+def test_best_release_skips_blocked_entries():
+    good = rel("Game (USA)", seeders=5)
+    bad = rel("Game (USA) [!]", seeders=50)
+    blocklist = Blocklist()
+    blocklist.add(bad, reason="failed")
+    assert best_release([good, bad], "game", SNES, blocklist=blocklist) is good
+
+
+def test_blocking_everything_yields_no_pick_rather_than_a_bad_one():
+    releases = [rel("Game (USA)"), rel("Game (Europe)")]
+    blocklist = Blocklist()
+    for release in releases:
+        blocklist.add(release, reason="x")
+    assert best_release(releases, "game", SNES, blocklist=blocklist) is None
+
+
+# --- both together ---------------------------------------------------------
+
+def test_a_blocklist_beats_a_preference():
+    """An operator who preferred a term and then blocked a specific release
+    meant the block. Scoring it highly and then taking it would be the worst
+    possible reading."""
+    release = rel("Game (USA) [!]")
+    blocklist = Blocklist()
+    blocklist.add(release, reason="corrupt")
+    verdict = judge(release, "game", SNES,
+                    profile=ReleaseProfile(preferred=[("[!]", 500)]),
+                    blocklist=blocklist)
+    assert not verdict.accepted

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,0 +1,175 @@
+"""Trusting an identity your reverse proxy already established.
+
+Authentik, Authelia, oauth2-proxy and Cloudflare Access all work the same way:
+they authenticate, then add a header naming the user. The app's job is to
+believe it -- but *only* from the proxy.
+
+That "only" is the entire security of the arrangement. A header is just text
+anybody can send, so an app that believes `X-authentik-username` from any
+source has not added SSO, it has added a way to become any user by typing one
+header. Every test below exists because of that sentence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from romarr.sso import FORWARD_PROVIDERS, ForwardAuth, trusted_peer
+
+
+# --- the peer check, which everything else depends on ---------------------
+
+@pytest.mark.parametrize("peer,allowed", [
+    ("10.0.0.5", ["10.0.0.0/8"]),
+    ("192.168.0.94", ["192.168.0.0/24"]),
+    ("127.0.0.1", ["127.0.0.1/32"]),
+    ("172.18.0.3", ["172.16.0.0/12"]),
+])
+def test_a_peer_inside_a_trusted_range_is_trusted(peer, allowed):
+    assert trusted_peer(peer, allowed)
+
+
+@pytest.mark.parametrize("peer,allowed", [
+    ("10.0.0.5", ["192.168.0.0/24"]),
+    ("192.168.1.7", ["192.168.0.0/24"]),
+    ("8.8.8.8", ["10.0.0.0/8"]),
+    ("", ["10.0.0.0/8"]),
+    ("not-an-ip", ["10.0.0.0/8"]),
+])
+def test_a_peer_outside_every_trusted_range_is_not(peer, allowed):
+    assert not trusted_peer(peer, allowed)
+
+
+def test_no_trusted_ranges_trusts_nobody():
+    """Fail closed. An empty list is a configuration that has not been
+    finished, and reading it as "trust everything" turns an unconfigured
+    install into an open one."""
+    assert not trusted_peer("10.0.0.5", [])
+    assert not trusted_peer("127.0.0.1", None)
+
+
+def test_a_bare_address_works_as_well_as_a_cidr():
+    assert trusted_peer("192.168.0.94", ["192.168.0.94"])
+    assert not trusted_peer("192.168.0.95", ["192.168.0.94"])
+
+
+# --- provider presets ------------------------------------------------------
+
+def test_the_providers_people_actually_run_are_presets():
+    for name in ("authentik", "authelia", "oauth2-proxy", "cloudflare-access",
+                 "tinyauth", "custom"):
+        assert name in FORWARD_PROVIDERS, name
+
+
+@pytest.mark.parametrize("provider,header", [
+    ("authentik", "X-authentik-username"),
+    ("authelia", "Remote-User"),
+    ("oauth2-proxy", "X-Forwarded-User"),
+    ("cloudflare-access", "Cf-Access-Authenticated-User-Email"),
+])
+def test_each_preset_names_the_header_that_provider_really_sends(provider, header):
+    assert FORWARD_PROVIDERS[provider]["user_header"] == header
+
+
+# --- believing the header --------------------------------------------------
+
+def sso(**kw):
+    kw.setdefault("provider", "authentik")
+    kw.setdefault("trusted_proxies", ["10.0.0.0/8"])
+    return ForwardAuth(**kw)
+
+
+def test_an_identity_from_the_proxy_is_accepted():
+    got = sso().identify({"X-authentik-username": "wade"}, peer="10.0.0.2")
+    assert got.ok and got.user == "wade"
+
+
+def test_the_same_header_from_anywhere_else_is_ignored_entirely():
+    """The whole point. Without the peer check this is a login bypass with a
+    one-line exploit: `curl -H 'X-authentik-username: admin'`."""
+    got = sso().identify({"X-authentik-username": "admin"}, peer="8.8.8.8")
+    assert not got.ok
+    assert not got.user
+    assert "not a trusted proxy" in got.reason
+
+
+def test_forward_auth_with_no_trusted_proxies_refuses_everyone():
+    got = ForwardAuth(provider="authentik", trusted_proxies=[]).identify(
+        {"X-authentik-username": "wade"}, peer="10.0.0.2")
+    assert not got.ok
+
+
+def test_a_trusted_proxy_that_sends_no_identity_is_not_a_login():
+    """The proxy is reachable but the request was never authenticated -- an
+    unprotected path in the proxy config, typically. Not an identity."""
+    got = sso().identify({}, peer="10.0.0.2")
+    assert not got.ok
+    assert "no identity header" in got.reason
+
+
+def test_the_header_is_matched_case_insensitively():
+    got = sso().identify({"x-authentik-username": "wade"}, peer="10.0.0.2")
+    assert got.ok and got.user == "wade"
+
+
+def test_a_custom_header_name_is_honoured():
+    got = ForwardAuth(provider="custom", user_header="X-Whoami",
+                      trusted_proxies=["10.0.0.0/8"]).identify(
+        {"X-Whoami": "wade"}, peer="10.0.0.2")
+    assert got.ok and got.user == "wade"
+
+
+# --- group restriction -----------------------------------------------------
+
+def test_a_required_group_is_enforced():
+    auth = sso(required_group="romarr-admins")
+    headers = {"X-authentik-username": "wade",
+               "X-authentik-groups": "users|romarr-admins|media"}
+    assert auth.identify(headers, peer="10.0.0.2").ok
+
+
+def test_somebody_outside_the_required_group_is_refused():
+    auth = sso(required_group="romarr-admins")
+    headers = {"X-authentik-username": "guest",
+               "X-authentik-groups": "users|media"}
+    got = auth.identify(headers, peer="10.0.0.2")
+    assert not got.ok
+    assert "romarr-admins" in got.reason
+
+
+def test_a_required_group_with_no_groups_header_is_refused():
+    """Authentik only sends groups if the provider is configured to. Treating
+    a missing header as "no restriction" would silently disable the
+    restriction the operator asked for."""
+    auth = sso(required_group="romarr-admins")
+    got = auth.identify({"X-authentik-username": "wade"}, peer="10.0.0.2")
+    assert not got.ok
+
+
+@pytest.mark.parametrize("raw", [
+    "users|romarr-admins",          # authentik
+    "users,romarr-admins",          # oauth2-proxy
+    "users romarr-admins",          # whitespace
+])
+def test_group_lists_are_read_in_every_separator_providers_use(raw):
+    auth = sso(required_group="romarr-admins")
+    headers = {"X-authentik-username": "w", "X-authentik-groups": raw}
+    assert auth.identify(headers, peer="10.0.0.2").ok
+
+
+def test_no_required_group_means_any_authenticated_user():
+    got = sso().identify({"X-authentik-username": "anyone"}, peer="10.0.0.2")
+    assert got.ok
+
+
+# --- how the peer is determined -------------------------------------------
+
+def test_the_peer_is_the_socket_not_a_forwarded_for_header():
+    """`X-Forwarded-For` is client-controlled. Taking the leftmost entry as
+    the peer lets anybody claim to be the proxy, which is the same bypass the
+    peer check exists to close, reintroduced through the back door.
+    """
+    got = sso().identify(
+        {"X-authentik-username": "admin", "X-Forwarded-For": "10.0.0.2"},
+        peer="8.8.8.8")
+    assert not got.ok

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -1,0 +1,157 @@
+"""Two-factor for the local password login.
+
+RFC 6238, so any authenticator app works and there is no dependency to add.
+The interesting parts are not the algorithm -- that is thirty lines and the
+RFC ships test vectors -- they are the three things implementations get wrong:
+accepting a code twice, comparing it with `==`, and having no way in when the
+phone is gone.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from romarr.totp import (
+    Totp, backup_codes, code_at, new_secret, provisioning_uri)
+
+
+# --- RFC 6238 test vectors, so the algorithm is right and not merely ------
+#     self-consistent
+
+RFC_SECRET_B32 = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"   # "12345678901234567890"
+
+
+@pytest.mark.parametrize("moment,expected", [
+    (59, "287082"),
+    (1111111109, "081804"),
+    (1111111111, "050471"),
+    (1234567890, "005924"),
+    (2000000000, "279037"),
+])
+def test_against_the_rfc_6238_vectors(moment, expected):
+    assert code_at(RFC_SECRET_B32, moment) == expected
+
+
+# --- secrets and enrolment -------------------------------------------------
+
+def test_a_secret_is_base32_and_long_enough():
+    secret = new_secret()
+    assert len(secret) >= 32
+    assert set(secret) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+    assert secret != new_secret()
+
+
+def test_the_provisioning_uri_is_what_an_authenticator_expects():
+    uri = provisioning_uri("GEZDGNBVGY3TQOJQ", account="wade", issuer="ROMarr")
+    assert uri.startswith("otpauth://totp/")
+    assert "ROMarr" in uri and "wade" in uri
+    assert "secret=GEZDGNBVGY3TQOJQ" in uri
+    assert "issuer=ROMarr" in uri
+
+
+def test_the_provisioning_uri_escapes_an_account_with_a_space():
+    uri = provisioning_uri("AAAA", account="wade ivy", issuer="ROMarr")
+    assert " " not in uri
+
+
+# --- verification ----------------------------------------------------------
+
+def test_the_current_code_is_accepted():
+    totp = Totp(RFC_SECRET_B32)
+    assert totp.verify(code_at(RFC_SECRET_B32, int(time.time())))
+
+
+def test_a_wrong_code_is_not():
+    assert not Totp(RFC_SECRET_B32).verify("000000")
+    assert not Totp(RFC_SECRET_B32).verify("")
+    assert not Totp(RFC_SECRET_B32).verify(None)
+
+
+def test_one_step_of_drift_is_tolerated_in_both_directions():
+    """Phone clocks drift and people type slowly. Zero tolerance produces
+    "my code is right and it says no" during the second either side of every
+    30-second boundary."""
+    now = int(time.time())
+    totp = Totp(RFC_SECRET_B32)
+    assert totp.verify(code_at(RFC_SECRET_B32, now - 30))
+    assert totp.verify(code_at(RFC_SECRET_B32, now + 30))
+
+
+def test_two_steps_of_drift_is_not():
+    now = int(time.time())
+    totp = Totp(RFC_SECRET_B32)
+    assert not totp.verify(code_at(RFC_SECRET_B32, now - 120))
+
+
+def test_a_code_cannot_be_used_twice():
+    """The replay window is real: a code is valid for 30 seconds plus the
+    drift tolerance, so anybody who sees one -- over the shoulder, in a proxy
+    log, in a screenshot -- can use it until it expires. Accepting it once is
+    the whole point of the counter.
+    """
+    totp = Totp(RFC_SECRET_B32)
+    code = code_at(RFC_SECRET_B32, int(time.time()))
+    assert totp.verify(code)
+    assert not totp.verify(code), "the same code must not work again"
+
+
+def test_replay_rejection_does_not_block_the_next_code():
+    now = int(time.time())
+    totp = Totp(RFC_SECRET_B32)
+    assert totp.verify(code_at(RFC_SECRET_B32, now))
+    assert totp.verify(code_at(RFC_SECRET_B32, now + 30))
+
+
+def test_codes_are_compared_in_constant_time():
+    """A byte-by-byte `==` leaks how much of a code was right through timing.
+    Six digits is a small enough space that this matters."""
+    import inspect
+
+    from romarr import totp as module
+    assert "compare_digest" in inspect.getsource(module.Totp.verify)
+
+
+def test_whitespace_and_hyphens_in_a_typed_code_are_tolerated():
+    now = int(time.time())
+    code = code_at(RFC_SECRET_B32, now)
+    assert Totp(RFC_SECRET_B32).verify(f"{code[:3]} {code[3:]}")
+
+
+# --- backup codes ----------------------------------------------------------
+
+def test_backup_codes_are_generated_and_distinct():
+    codes = backup_codes(10)
+    assert len(codes) == 10 == len(set(codes))
+    assert all(len(c) >= 8 for c in codes)
+
+
+def test_a_backup_code_works_once_and_is_then_spent():
+    """The way back in when the phone is gone. Reusable backup codes are a
+    password that never expires, so each one is consumed."""
+    codes = backup_codes(3)
+    totp = Totp(RFC_SECRET_B32, backup=list(codes))
+    assert totp.verify(codes[0])
+    assert not totp.verify(codes[0])
+    assert codes[0] not in totp.backup
+
+
+def test_the_other_backup_codes_survive_one_being_used():
+    codes = backup_codes(3)
+    totp = Totp(RFC_SECRET_B32, backup=list(codes))
+    totp.verify(codes[0])
+    assert totp.verify(codes[1])
+
+
+def test_a_backup_code_is_matched_regardless_of_case_and_spacing():
+    codes = backup_codes(2)
+    totp = Totp(RFC_SECRET_B32, backup=list(codes))
+    assert totp.verify(codes[0].lower().replace("-", " "))
+
+
+def test_no_secret_means_two_factor_is_off_not_open():
+    """A user without 2FA enrolled must not have every code accepted."""
+    totp = Totp("")
+    assert not totp.verify("000000")
+    assert not totp.enabled

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,204 @@
+"""Upgrades, tags and manual import."""
+
+from __future__ import annotations
+
+import zlib
+
+import pytest
+
+from romarr.dat import BAD_DUMP, DatIndex, UNKNOWN, VERIFIED, parse_dat
+from romarr.platforms import by_slug
+from romarr.upgrade import (
+    is_upgrade, matches_tags, merge_tags, normalise_tag, scan)
+
+
+# --- upgrades: the one comparison that is a fact ---------------------------
+
+def test_verified_beats_unknown():
+    """Radarr upgrades on a quality ladder, which is taste. This is not: an
+    unverified file replaced by a verified one is a statement about the bytes,
+    and it is the only upgrade rule in this class of tool that cannot be
+    wrong."""
+    got = is_upgrade(UNKNOWN, VERIFIED)
+    assert got.upgrade and "verified" in got.reason
+
+
+def test_verified_beats_a_bad_dump():
+    assert is_upgrade(BAD_DUMP, VERIFIED).upgrade
+
+
+def test_unknown_beats_a_bad_dump():
+    """A bad dump ranks BELOW unknown deliberately. Unknown is the normal
+    state of homebrew and translations; bad-dump means a DAT knows what this
+    should be and this is not it. Ranking them equal leaves a corrupt file
+    sitting there forever with nothing able to replace it."""
+    assert is_upgrade(BAD_DUMP, UNKNOWN).upgrade
+
+
+def test_nothing_downgrades():
+    assert not is_upgrade(VERIFIED, UNKNOWN).upgrade
+    assert not is_upgrade(VERIFIED, BAD_DUMP).upgrade
+    assert not is_upgrade(UNKNOWN, BAD_DUMP).upgrade
+
+
+def test_two_verified_copies_are_not_an_upgrade():
+    """Re-downloading a byte-identical game is churn, not an upgrade."""
+    got = is_upgrade(VERIFIED, VERIFIED, current_size=100, candidate_size=200)
+    assert not got.upgrade
+
+
+def test_a_sidegrade_is_possible_but_must_be_asked_for():
+    assert is_upgrade(UNKNOWN, UNKNOWN, current_size=100, candidate_size=200,
+                      allow_sidegrade=True).upgrade
+    assert not is_upgrade(UNKNOWN, UNKNOWN, current_size=200,
+                          candidate_size=100, allow_sidegrade=True).upgrade
+
+
+def test_an_unrecognised_verdict_is_treated_as_unknown():
+    assert is_upgrade("nonsense", VERIFIED).upgrade
+
+
+def test_every_decision_explains_itself():
+    for current, candidate in [(UNKNOWN, VERIFIED), (VERIFIED, UNKNOWN),
+                               (VERIFIED, VERIFIED)]:
+        assert is_upgrade(current, candidate).reason
+
+
+# --- tags ------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("Favourites", "favourites"),
+    ("  favourites  ", "favourites"),
+    ("FAVOURITES", "favourites"),
+    ("co-op games", "co-op games"),
+    ("bad!!chars##", "badchars"),
+    ("multiple   spaces", "multiple spaces"),
+])
+def test_tags_are_normalised(raw, expected):
+    """A tag is typed by a person. "Favourites", "favourites " and
+    "FAVOURITES" are one tag, and treating them as three produces a filter
+    list nobody can use."""
+    assert normalise_tag(raw) == expected
+
+
+def test_merging_deduplicates_and_sorts():
+    """Sorted because tags render as a row of chips, and a set that reorders
+    itself on every edit is unreadable."""
+    assert merge_tags(["b", "A"], adding=["a", "c"]) == ["a", "b", "c"]
+
+
+def test_removing_a_tag():
+    assert merge_tags(["a", "b"], removing=["A"]) == ["b"]
+
+
+def test_empty_tags_are_dropped_rather_than_stored():
+    assert merge_tags(["", "  ", "!!"], adding=[""]) == []
+
+
+def test_matching_requires_every_tag():
+    assert matches_tags(["a", "b"], ["a"])
+    assert matches_tags(["a", "b"], ["A", "b"])
+    assert not matches_tags(["a"], ["a", "b"])
+
+
+def test_requiring_nothing_matches_everything():
+    assert matches_tags([], [])
+    assert matches_tags(["a"], None)
+
+
+# --- manual import ---------------------------------------------------------
+
+PLATFORMS = [by_slug(s) for s in ("snes", "psx", "genesis-slash-megadrive",
+                                  "atari2600", "nes")]
+
+
+def test_a_scan_finds_roms(tmp_path):
+    (tmp_path / "Super Metroid (USA).sfc").write_bytes(b"\x00" * 1024)
+    (tmp_path / "Contra (USA).nes").write_bytes(b"\x00" * 512)
+    got = scan(tmp_path, PLATFORMS)
+    assert {c.filename for c in got.candidates} == {
+        "Super Metroid (USA).sfc", "Contra (USA).nes"}
+    assert {c.platform for c in got.candidates} == {"snes", "nes"}
+
+
+def test_extras_are_skipped_not_listed(tmp_path):
+    """Listing twenty rows of readmes makes an operator read past them to find
+    the four that matter."""
+    (tmp_path / "Game.sfc").write_bytes(b"\x00")
+    for junk in ("readme.nfo", "cover.png", "notes.txt", "hashes.md5"):
+        (tmp_path / junk).write_bytes(b"x")
+    got = scan(tmp_path, PLATFORMS)
+    assert [c.filename for c in got.candidates] == ["Game.sfc"]
+    assert got.skipped == 4
+
+
+def test_the_parent_directory_settles_an_ambiguous_extension(tmp_path):
+    """`.bin` is Mega Drive, Atari 2600 and a PlayStation track. A file in a
+    folder called `psx` is taken at its word -- that folder name is a
+    deliberate statement by whoever laid the library out."""
+    folder = tmp_path / "psx"
+    folder.mkdir()
+    (folder / "Game (Track 1).bin").write_bytes(b"\x00" * 2048)
+    got = scan(tmp_path, PLATFORMS)
+    assert got.candidates[0].platform == "psx"
+    assert "folder" in got.candidates[0].reason
+
+
+def test_an_ambiguous_extension_with_no_hint_says_so(tmp_path):
+    """It still offers a guess -- refusing to list the file would hide it --
+    but the reason tells the operator to confirm."""
+    (tmp_path / "Mystery.bin").write_bytes(b"\x00" * 2048)
+    got = scan(tmp_path, PLATFORMS)
+    assert len(got.candidates) == 1
+    assert "confirm" in got.candidates[0].reason
+
+
+def test_an_unknown_extension_is_skipped(tmp_path):
+    (tmp_path / "thing.qqq").write_bytes(b"\x00")
+    got = scan(tmp_path, PLATFORMS)
+    assert got.candidates == [] and got.skipped == 1
+
+
+def test_a_scan_recurses(tmp_path):
+    deep = tmp_path / "a" / "b" / "snes"
+    deep.mkdir(parents=True)
+    (deep / "Game.sfc").write_bytes(b"\x00")
+    assert len(scan(tmp_path, PLATFORMS).candidates) == 1
+
+
+def test_scanning_something_that_is_not_a_directory_is_reported(tmp_path):
+    got = scan(tmp_path / "nope", PLATFORMS)
+    assert got.candidates == [] and "not a directory" in got.error
+
+
+def test_a_scan_is_bounded(tmp_path):
+    """A pointed-at-root scan must not try to list a million files."""
+    for i in range(20):
+        (tmp_path / f"g{i}.sfc").write_bytes(b"\x00")
+    assert len(scan(tmp_path, PLATFORMS, limit=5).candidates) == 5
+
+
+def test_a_scan_verifies_against_a_dat_when_one_is_loaded(tmp_path):
+    """The strongest statement available about a found file, and it names the
+    actual game rather than the filename somebody typed."""
+    body = b"\x5A" * 4096
+    crc = f"{zlib.crc32(body) & 0xFFFFFFFF:08x}"
+    index = DatIndex()
+    index.add(parse_dat(f"""<?xml version="1.0"?><datafile>
+      <header><name>SNES</name></header>
+      <game name="Super Metroid (USA)">
+        <rom name="x.sfc" size="{len(body)}" crc="{crc.upper()}"/>
+      </game></datafile>"""))
+
+    (tmp_path / "badly named file.sfc").write_bytes(body)
+    got = scan(tmp_path, PLATFORMS, dats=index)
+
+    assert got.candidates[0].verdict == VERIFIED
+    assert got.candidates[0].game == "Super Metroid (USA)"
+    assert "Super Metroid (USA)" in got.candidates[0].reason
+
+
+def test_a_scan_without_dats_still_works(tmp_path):
+    (tmp_path / "Game.sfc").write_bytes(b"\x00")
+    got = scan(tmp_path, PLATFORMS)
+    assert got.candidates[0].verdict == UNKNOWN

--- a/tests/test_verified_import.py
+++ b/tests/test_verified_import.py
@@ -1,0 +1,207 @@
+"""What landed, checked against what should have landed.
+
+The import used to end at "the bytes are in the library". With a DAT loaded
+it ends at "the bytes in the library are the published dump", which is a
+different and much stronger claim -- and the one thing this class of tool has
+never been able to make.
+"""
+
+from __future__ import annotations
+
+import zlib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from romarr.dat import BAD_DUMP, DatIndex, UNKNOWN, VERIFIED, parse_dat
+from romarr.library import import_rom
+from romarr.platforms import by_slug
+
+SNES = by_slug("snes")
+PSX = by_slug("psx")
+
+ROM = b"\x5A" * 65536
+CRC = f"{zlib.crc32(ROM) & 0xFFFFFFFF:08x}"
+
+DAT = f"""<?xml version="1.0"?><datafile>
+  <header><name>Nintendo - SNES</name></header>
+  <game name="Super Metroid (USA)">
+    <rom name="Super Metroid (USA).sfc" size="{len(ROM)}" crc="{CRC.upper()}"/>
+  </game>
+</datafile>"""
+
+
+@pytest.fixture
+def dats():
+    index = DatIndex()
+    index.add(parse_dat(DAT))
+    return index
+
+
+def make_zip(path: Path, members: dict) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    return path
+
+
+# --- the claim -------------------------------------------------------------
+
+def test_a_correct_rom_is_reported_verified(tmp_path, dats):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Super Metroid (USA).sfc": ROM})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=dats)
+
+    assert result.ok
+    assert result.verification.status == VERIFIED
+    assert result.verification.game == "Super Metroid (USA)"
+
+
+def test_a_corrupt_rom_is_reported_as_a_bad_dump(tmp_path, dats):
+    """Same size, different bytes. Every other *arr imports this and tells you
+    it succeeded, because filename scoring cannot see inside a file."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    corrupt = b"\x00" + ROM[1:]
+    make_zip(downloads / "g.zip", {"Super Metroid (USA).sfc": corrupt})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=dats)
+
+    assert result.verification.status == BAD_DUMP
+    assert "checksum" in result.verification.detail
+
+
+def test_an_unrecognised_rom_is_unknown_and_still_imports(tmp_path, dats):
+    """Homebrew, translations and anything newer than the DAT. Refusing these
+    would make loading a DAT a downgrade."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Homebrew Demo.sfc": b"\x11" * 4096})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=dats)
+
+    assert result.ok, result.reason
+    assert result.verification.status == UNKNOWN
+
+
+def test_a_bad_dump_still_imports_by_default(tmp_path, dats):
+    """Reported, not refused. The operator may have grabbed the only copy that
+    exists, and a tool that silently discards it has made that decision for
+    them -- the verdict is on the result either way."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Super Metroid (USA).sfc": b"\x00" + ROM[1:]})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=dats)
+
+    assert result.ok
+    assert result.destination.exists()
+
+
+def test_a_bad_dump_can_be_refused_when_asked(tmp_path, dats):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Super Metroid (USA).sfc": b"\x00" + ROM[1:]})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=dats,
+                        require_verified=True)
+
+    assert not result.ok
+    assert "checksum" in result.reason
+    assert not (lib / "snes").exists(), "nothing may be left behind"
+
+
+# --- headers, through the whole pipeline -----------------------------------
+
+def test_a_headered_import_verifies(tmp_path, dats):
+    """The end-to-end version of the copier-header trap. Without the skip,
+    every SNES import ever made would report "unknown"."""
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip",
+             {"Super Metroid (USA).smc": b"\x00" * 512 + ROM})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=dats)
+
+    assert result.verification.status == VERIFIED
+
+
+# --- discs verify per track ------------------------------------------------
+
+def test_a_disc_set_verifies_every_track(tmp_path):
+    """Redump lists each track as its own <rom>, so a cue+bin set is verified
+    member by member. One good track and one corrupt one is not a good
+    import."""
+    cue = b'FILE "Game (USA).bin" BINARY\n'
+    track = b"\x7E" * 40960
+    index = DatIndex()
+    index.add(parse_dat(f"""<?xml version="1.0"?><datafile>
+      <header><name>Sony - PlayStation</name></header>
+      <game name="Game (USA)">
+        <rom name="Game (USA).cue" size="{len(cue)}"
+             crc="{zlib.crc32(cue) & 0xFFFFFFFF:08x}"/>
+        <rom name="Game (USA).bin" size="{len(track)}"
+             crc="{zlib.crc32(track) & 0xFFFFFFFF:08x}"/>
+      </game></datafile>"""))
+
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "d.zip",
+             {"Game (USA).cue": cue, "Game (USA).bin": track})
+
+    result = import_rom(downloads / "d.zip", PSX, lib, dats=index)
+
+    assert result.ok, result.reason
+    assert result.verification.status == VERIFIED
+    assert result.verification.game == "Game (USA)"
+
+
+def test_one_corrupt_track_fails_the_whole_set(tmp_path):
+    cue = b'FILE "Game (USA).bin" BINARY\n'
+    track = b"\x7E" * 40960
+    index = DatIndex()
+    index.add(parse_dat(f"""<?xml version="1.0"?><datafile>
+      <header><name>Sony - PlayStation</name></header>
+      <game name="Game (USA)">
+        <rom name="Game (USA).cue" size="{len(cue)}"
+             crc="{zlib.crc32(cue) & 0xFFFFFFFF:08x}"/>
+        <rom name="Game (USA).bin" size="{len(track)}"
+             crc="{zlib.crc32(track) & 0xFFFFFFFF:08x}"/>
+      </game></datafile>"""))
+
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "d.zip",
+             {"Game (USA).cue": cue, "Game (USA).bin": b"\x00" + track[1:]})
+
+    result = import_rom(downloads / "d.zip", PSX, lib, dats=index)
+
+    assert result.verification.status != VERIFIED
+
+
+# --- nothing changes for an operator with no DATs -------------------------
+
+def test_without_dats_the_import_behaves_exactly_as_before(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Super Metroid (USA).sfc": ROM})
+
+    result = import_rom(downloads / "g.zip", SNES, lib)
+
+    assert result.ok
+    assert result.destination == lib / "snes" / "Super Metroid (USA).sfc"
+    assert result.verification.status == UNKNOWN
+
+
+def test_an_empty_index_does_not_turn_imports_into_errors(tmp_path):
+    downloads, lib = tmp_path / "dl", tmp_path / "lib"
+    downloads.mkdir()
+    make_zip(downloads / "g.zip", {"Super Metroid (USA).sfc": ROM})
+
+    result = import_rom(downloads / "g.zip", SNES, lib, dats=DatIndex())
+
+    assert result.ok
+    assert result.verification.status == UNKNOWN

--- a/tests/test_wired.py
+++ b/tests/test_wired.py
@@ -1,0 +1,82 @@
+"""Every module is reachable from the running service.
+
+This file exists because `romarr/metadata.py` shipped with 249 lines, 27
+green tests, and nothing in `app.py` importing it. It was dead code with a
+certificate -- the exact "configuration that tests green and does nothing"
+failure this project has found three times in other people's software,
+committed in its own.
+
+Unit tests prove a module is correct. They cannot prove anybody calls it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1] / "romarr"
+
+#: Modules that are legitimately not imported by the service.
+#:
+#: Kept explicit and tiny. A growing exemption list is the same failure
+#: arriving by a slower route.
+STANDALONE = {
+    "__init__",
+    "__main__",   # the entry point; it imports app, not the other way round
+    "app",        # the root of the graph, so it cannot import itself
+}
+
+
+def modules() -> list[str]:
+    return sorted(p.stem for p in ROOT.glob("*.py") if p.stem not in STANDALONE)
+
+
+def imported_names(path: pathlib.Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level:
+            if node.module:
+                found.add(node.module.split(".")[0])
+            else:
+                # `from . import hub` -- the names ARE the modules, and
+                # missing this form is how a wired module looks unwired.
+                found.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("romarr."):
+                    found.add(alias.name.split(".")[1])
+    return found
+
+
+def reachable() -> set[str]:
+    """Everything app.py imports, plus what those modules import."""
+    seen = imported_names(ROOT / "app.py")
+    frontier = list(seen)
+    while frontier:
+        name = frontier.pop()
+        path = ROOT / f"{name}.py"
+        if not path.exists():
+            continue
+        for found in imported_names(path):
+            if found not in seen:
+                seen.add(found)
+                frontier.append(found)
+    return seen
+
+
+@pytest.mark.parametrize("module", modules())
+def test_the_service_can_reach_every_module(module):
+    assert module in reachable(), (
+        f"romarr/{module}.py is never imported by the running service. "
+        "Either wire it up or delete it -- a tested module nobody calls is "
+        "dead code with a certificate."
+    )
+
+
+def test_the_exemption_list_stays_small():
+    """It is the escape hatch, and an escape hatch that grows is the failure
+    arriving by a slower route."""
+    assert len(STANDALONE) <= 4, sorted(STANDALONE)


### PR DESCRIPTION
Stacked on #5.

## The logic

Feature count is the wrong axis. Radarr has 14 download clients and 24 notification providers; gamarr copies that shape. But **no *arr can tell you whether the file it imported is correct** — there is no canonical hash for a movie, so the last mile is always "something arrived, it is probably fine". gamarr's "safety scoring" reads filenames.

ROMs are the one domain where that is solvable. No-Intro and Redump publish the CRC32, MD5 and SHA1 of every correct dump in existence. So ROMarr can make a claim nothing else in this category can: **the bytes in your library are the published dump.**

That is the standard this PR sets. The other two pieces are the table stakes that had to come first.

## 1. Authentication — there was none

`_guard` is an exception handler, not a gate. Every endpoint, including the ones that queue torrents and rewrite settings, answered anybody who could reach the port.

Secure by default: key generated on first run, `X-Api-Key` / `Authorization: Bearer` / `?apikey=`, HttpOnly SameSite session for browsers. `ROMARR_AUTH=disabled` for installs behind an authenticating proxy — a deliberate setting, never something a *missing* key degrades into.

Two bugs found wiring it: `/api/health` was handing library paths and client URLs to unauthenticated callers, and refusing a POST without draining its body aborted the connection so the client never saw the 401.

## 2. Nine indexer types, not one

`prowlarr jackett nzbhydra2 cardigann bitmagnet torznab newznab torrentrss torrentpotato`

Jackett, NZBHydra2, Cardigann and Bitmagnet are Torznab/Newznab underneath — four table rows over two existing clients. The substance is the URL hint: pointing at Jackett's homepage instead of its Torznab endpoint is the top way one of these tests green and returns nothing.

Two needed real parsers, each with a trap that makes the indexer silently useless:
- **TorrentPotato reports size in megabytes.** Read as bytes, a 3 MB SNES release becomes 3 bytes and is rejected as "too small to be a ROM".
- **RSS feeds carry no category and no seeder count** — the two fields that decide whether a release survives scoring at all.

A test asserts every non-Prowlarr type can actually be built into a searchable client, because configuration that tests green and searches nothing is the failure this replaces.

## 3. DAT verification

Three verdicts, kept distinct:

| | |
|---|---|
| **verified** | the hash is in a DAT; this is the published dump |
| **bad-dump** | a file the exact size of a known ROM whose hash does not match — corrupt, patched or tampered with |
| **unknown** | nothing matched. **Not** bad: homebrew, translations and an out-of-date DAT all land here |

**The copier-header rule is why naive versions of this match nothing.** No-Intro hashes cartridge contents; iNES/fwNES/Lynx/7800 headers are added afterwards, and a SNES dump may or may not carry a 512-byte copier header with nothing in the extension to say. Hash the file as it sits and every NES and SNES import returns "unknown" — the feature looks useless rather than broken. The SNES rule is arithmetic: 512 over a multiple of 32768.

A set is verified only when **every** member matches, because Redump lists each disc track as its own `<rom>` — a good cue beside a corrupt track is not a good import.

1G1R resolves clones to their parent using the same region ladder the scorer uses, so a deduplicated set and a fresh grab agree about which dump is wanted. A game whose only dumps fall outside the preference is kept, not dropped.

One bug caught by its own test: the header probe in `hash_file` built a buffer the size of the whole file — 4 GB for a PS2 image, reintroducing the exact problem chunked hashing exists to avoid, one line above it.

## Proof

**477 tests green.** Auth is tested against a real socket, not just in isolation — a gate that is correct and unwired is exactly as open as no gate.

## Not in this PR

Blocklist, release profiles, outbound notifications, more download clients, and the plugin catalogue are next. Radarr's client and notification lists are mostly a driver table like the indexer one, so they scale; the DAT work was the part that had to be built rather than tabulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)