### PR TITLE
Fix qBittorrent 5.x login and import all ROMs from multi-ROM archives

### DIFF
--- a/romarr/app.py
+++ b/romarr/app.py
@@ -1432,23 +1432,35 @@ class ROMarr:
             target_cfg, target_lib = target
             label = target_cfg.get("name") or getattr(target_lib, "name", "library")
 
-            outcome = import_rom(path, platform, self.library_root(target_cfg))
-            if outcome.ok:
+            outcomes = import_rom(path, platform, self.library_root(target_cfg))
+            if not outcomes:
+                self.store.record(Event(kind="failed", game=name,
+                                        platform=platform.slug,
+                                        detail="no ROMs found in download"))
+                results.append({"name": name, "ok": False,
+                                "reason": "no ROMs found", "library": label})
+                continue
+
+            any_ok = any(o.ok for o in outcomes)
+            for outcome in outcomes:
+                if outcome.ok:
+                    self.store.record(Event(kind="imported", game=name,
+                                            platform=platform.slug, release=name,
+                                            library=label,
+                                            detail=str(outcome.destination)))
+                else:
+                    self.store.record(Event(kind="failed", game=name,
+                                            platform=platform.slug,
+                                            detail=outcome.reason))
+            if any_ok:
                 if self.store.settings.get("rescan_after_import", True):
                     target_lib.rescan(platform.slug)
-                self.store.record(Event(kind="imported", game=name,
-                                        platform=platform.slug, release=name,
-                                        library=label,
-                                        detail=str(outcome.destination)))
-                # It has arrived, so it is no longer wanted.
                 for w in list(self.store.wanted):
                     if w.platform == platform.slug and w.game.lower() in name.lower():
                         self.store.fulfil(w.game, w.platform)
-            else:
-                self.store.record(Event(kind="failed", game=name,
-                                        platform=platform.slug, detail=outcome.reason))
-            results.append({"name": name, "ok": outcome.ok,
-                            "reason": outcome.reason, "library": label})
+            results.append({"name": name, "ok": any_ok,
+                            "reason": "" if any_ok else str(outcomes[0].reason),
+                            "library": label})
         return results
 
 

--- a/romarr/clients.py
+++ b/romarr/clients.py
@@ -60,7 +60,7 @@ class QBittorrent:
             data={"username": self._config.username, "password": self._config.password},
             timeout=self._config.timeout,
         )
-        self._authed = response.ok and response.text.strip() == "Ok."
+        self._authed = response.ok and (response.status_code == 204 or response.text.strip() == "Ok.")
         if not self._authed:
             log.warning("qbittorrent login rejected (status %s)", response.status_code)
         return self._authed

--- a/romarr/library.py
+++ b/romarr/library.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from .dat import BAD_DUMP, UNKNOWN, VERIFIED, Match, hash_bytes
 from .platforms import Platform
-from .selection import pick_rom_set
+from .selection import pick_all_rom_sets, pick_rom_set
 
 log = logging.getLogger(__name__)
 
@@ -296,89 +296,88 @@ def verify_set(source, members, dats) -> Match:
 
 def import_rom(download: Path, platform: Platform, library_root: Path, *,
                overwrite: bool = False, dats=None,
-               require_verified: bool = False) -> ImportResult:
-    """Place the ROM from a finished download into RomM's library.
+               require_verified: bool = False) -> list[ImportResult]:
+    """Place every ROM from a finished download into the library.
 
-    A cartridge lands as one file, exactly as before. A disc lands as a
-    directory holding every file of the set, which is the layout the live
-    library already uses for multi-track rips -- so a disc ROMarr imported is
-    indistinguishable from one filed by hand.
+    A cartridge zip may hold several games (a 3-in-1 collection, a bundle)
+    and every one is imported.  A disc lands as a directory holding every
+    file of the set, which is the layout the live library already uses for
+    multi-track rips.
     """
     if not download.exists():
-        # Almost always a mount problem rather than a missing download: the
-        # client has the file and reported where IT sees it, and this process
-        # cannot see that path. "does not exist" on its own sends people looking
-        # for a lost download that is sitting right there, so say which of the
-        # two fixes applies.
-        return ImportResult(
-            False, None,
+        msg = (
             f"download path does not exist in this container: {download}. "
             "Mount the download client's completed directory at that exact "
             "path, or add a remote path mapping under Settings -> Media "
             "Management.")
+        return [ImportResult(False, None, msg)]
 
     try:
         source = _source_for(download, platform)
         candidates = source.names()
     except MissingArchiveTool as exc:
-        return ImportResult(False, None, str(exc))
+        return [ImportResult(False, None, str(exc))]
 
-    chosen = pick_rom_set(candidates, platform, read=source.read)
-    if chosen is None:
-        return ImportResult(
+    chosen_sets = pick_all_rom_sets(candidates, platform, read=source.read)
+    if not chosen_sets:
+        return [ImportResult(
             False, None,
-            f"no {platform.name} ROM among {len(candidates)} file(s)",
-        )
+            f"no {platform.name} ROM among {len(candidates)} file(s)")]
 
-    # Verify before writing, so `require_verified` can refuse without leaving
-    # a rejected dump behind for somebody to find later and wonder about.
-    verdict = verify_set(source, chosen.members, dats)
-    if require_verified and verdict.status != VERIFIED:
-        return ImportResult(
-            False, None,
-            f"refused: {verdict.detail or verdict}",
-            verification=verdict)
-
-    target_dir = library_root / platform.slug
-
-    # A set of one keeps the layout it has always had. Wrapping every
-    # cartridge in a directory would rewrite the shape of an existing library
-    # for no gain.
-    if not chosen.is_multi_file:
-        target_dir.mkdir(parents=True, exist_ok=True)
-        destination = target_dir / Path(chosen.primary).name
-        if destination.exists() and not overwrite:
-            return ImportResult(False, destination, "already in the library")
-        source.copy(chosen.primary, destination)
-        log.info("imported %s -> %s", chosen.primary, destination)
-        return ImportResult(True, destination, verification=verdict)
-
-    destination = target_dir / _set_name(chosen.primary)
-    if destination.exists() and any(destination.iterdir()) and not overwrite:
-        return ImportResult(False, destination, "already in the library")
-    destination.mkdir(parents=True, exist_ok=True)
-
-    # Members are flattened to their base names. `pick_rom_set` only ever
-    # returns members from one directory, so nothing is lost -- and a set
-    # written by base name cannot traverse out of the directory it was given,
-    # which makes the sidecar path safe by construction rather than by check.
-    written: dict[str, str] = {}
-    for member in chosen.members:
-        name = Path(member.replace("\\", "/")).name
-        if not is_safe_name(name, destination):
-            log.warning("refusing set member with an unusable name: %r", member)
+    results: list[ImportResult] = []
+    for chosen in chosen_sets:
+        verdict = verify_set(source, chosen.members, dats)
+        if require_verified and verdict.status != VERIFIED:
+            results.append(ImportResult(
+                False, None,
+                f"refused: {verdict.detail or verdict}",
+                verification=verdict))
             continue
-        if name in written:
-            return ImportResult(
-                False, destination,
-                f"two files in this download are both called {name!r} "
-                f"({written[name]} and {member}); refusing to guess which "
-                "one the game needs")
-        source.copy(member, destination / name)
-        written[name] = member
 
-    log.info("imported %d files -> %s", len(written), destination)
-    return ImportResult(True, destination, verification=verdict)
+        target_dir = library_root / platform.slug
+
+        if not chosen.is_multi_file:
+            target_dir.mkdir(parents=True, exist_ok=True)
+            destination = target_dir / Path(chosen.primary).name
+            if destination.exists() and not overwrite:
+                results.append(
+                    ImportResult(False, destination, "already in the library"))
+                continue
+            source.copy(chosen.primary, destination)
+            log.info("imported %s -> %s", chosen.primary, destination)
+            results.append(ImportResult(True, destination,
+                                        verification=verdict))
+            continue
+
+        destination = target_dir / _set_name(chosen.primary)
+        if destination.exists() and any(destination.iterdir()) and not overwrite:
+            results.append(
+                ImportResult(False, destination, "already in the library"))
+            continue
+        destination.mkdir(parents=True, exist_ok=True)
+
+        written: dict[str, str] = {}
+        for member in chosen.members:
+            name = Path(member.replace("\\", "/")).name
+            if not is_safe_name(name, destination):
+                log.warning("refusing set member with an unusable name: %r",
+                            member)
+                continue
+            if name in written:
+                results.append(ImportResult(
+                    False, destination,
+                    f"two files in this download are both called {name!r} "
+                    f"({written[name]} and {member}); refusing to guess which "
+                    "one the game needs"))
+                break
+            source.copy(member, destination / name)
+            written[name] = member
+        else:
+            log.info("imported %d files -> %s", len(written), destination)
+            results.append(ImportResult(True, destination,
+                                        verification=verdict))
+
+    return results
 
 
 def _set_name(primary: str) -> str:

--- a/romarr/selection.py
+++ b/romarr/selection.py
@@ -569,6 +569,54 @@ def pick_rom_set(filenames: list[str], platform: Platform, *,
     return None
 
 
+def pick_all_rom_sets(filenames: list[str], platform: Platform, *,
+                      read=None) -> list[RomSet]:
+    """Every valid ROM set the archive holds, not just the best one.
+
+    A cartridge zip may bundle several ROMs (a 3-in-1 collection, a bundle of
+    homebrew).  pick_rom_set keeps the one that ranks highest; this returns all
+    of them so that importing a multi-ROM zip does not silently drop games.
+    Disc releases and playlists are unchanged -- a cue with its bins is one
+    game regardless.
+    """
+    if not filenames:
+        return []
+
+    playable = [f for f in filenames if not _is_extra(f)]
+
+    if _PLAYLIST in platform.extensions:
+        playlists = [f for f in playable if f.lower().endswith(_PLAYLIST)]
+        if playlists:
+            sets = []
+            for primary in sorted(playlists,
+                                  key=lambda f: (-_region_rank(f), len(f))):
+                listed = _playlist_members(primary, playable, read)
+                sets.append(RomSet(primary, (primary, *listed)))
+            return sets if sets else []
+
+    all_matches = []
+    for ext in platform.extensions:
+        all_matches.extend(f for f in playable if f.lower().endswith(ext))
+
+    if not all_matches:
+        return []
+
+    all_matches.sort(key=lambda f: (-_region_rank(f), len(f)))
+
+    consumed: set[str] = set()
+    sets: list[RomSet] = []
+
+    for primary in all_matches:
+        if primary in consumed:
+            continue
+        sidecars = _sidecars_for(primary, playable, read)
+        members = (primary, *sidecars)
+        consumed.update(members)
+        sets.append(RomSet(primary, members))
+
+    return sets
+
+
 def _sidecars_for(primary: str, filenames: list[str], read) -> tuple[str, ...]:
     """The track files `primary` cannot boot without.
 


### PR DESCRIPTION
## Summary

Two fixes discovered while deploying ROMarr in a qBittorrent 5.x + RomM stack:

### 1. qBittorrent 5.x auth login returns 204

qBittorrent 5.x (linuxserver.io image, qBittorrent 5.0+) returns HTTP 204 with an empty body on successful auth/login, where previous versions returned 200 with "Ok.". ROMarr treated 204 as a failed login, producing "qbittorrent login rejected (status 204)" warnings and never importing completed downloads.

**Fix**: Accept 204 as success in addition to the legacy 200+"Ok." check.

### 2. Multi-ROM cartridge archives drop all but one game

When a torrent contains multiple ROMs for the same platform (e.g. a 3-in-1 NES collection zip), pick_rom_set selects only the single best-ranked match and the other games are silently dropped.

**Fix**: Added pick_all_rom_sets() which returns every valid RomSet from an archive. import_rom now iterates over all sets, producing separate import events and ROM files for each game. Disc releases and playlists are unchanged.

## Changes

| File | Change |
|------|--------|
| clients.py | Accept HTTP 204 as successful qBittorrent login |
| selection.py | Add pick_all_rom_sets() |
| library.py | import_rom returns list, imports all sets |
| app.py | Iterates over multiple import results, rescans once |

## Tested

- qBittorrent 5.0.1 (linuxserver.io), RomM 3.x, Python 3.13
- Multi-ROM zip: 3 NES games from one .zip, each with its own imported event