### PR TITLE
Fix ROM Hub confinement in Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -116,7 +116,7 @@ jobs:
           echo "--- the pieces that are easy to lose ---"
           docker exec smoke sh -c 'command -v bsdtar >/dev/null' \
             || { echo "bsdtar missing"; exit 1; }
-          docker exec smoke python -c "import requests, rom_hub" \
+          docker exec smoke python -c "import requests, rom_hub; from rom_hub.sandbox import install; install()" \
             || { echo "a dependency did not install"; exit 1; }
 
           echo "--- privileges were dropped ---"

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,11 @@ RUN python -c "import pathlib,sysconfig; p=pathlib.Path(sysconfig.get_path('pure
 # only failed when the Plugins page asked pyseccomp to find its C library. Load
 # a real restrictive filter during the build so that exact failure cannot be
 # published again.
-RUN if [ "$TARGETARCH" != "arm" ]; then \
+# The CI smoke image is native amd64. The multi-arch publish that follows runs
+# arm64 under QEMU, where seccomp_load is canceled by the emulator (errno 125)
+# even though the same filter loads on native Docker. Prove the actual image on
+# the native leg and do not mistake QEMU's build environment for arm64 runtime.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
       python -c "import rom_hub, pyseccomp; from rom_hub.sandbox import install; install()"; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN if [ "$TARGETARCH" != "arm" ]; then \
 
 FROM python:3.13-alpine
 
+ARG TARGETARCH
+
 # su-exec drops privileges in the entrypoint; it takes numeric ids, so no
 # shadow package and no user has to exist in the image. tzdata makes TZ work.
 #
@@ -46,6 +48,23 @@ FROM python:3.13-alpine
 RUN apk add --no-cache su-exec tzdata libarchive-tools libseccomp
 
 COPY --from=builder /install /usr/local
+
+# pyseccomp asks ctypes.util.find_library("seccomp") before opening the C
+# library. On Alpine that helper relies on linker/compiler discovery tools
+# which belong in the builder, so it returns None even though the runtime
+# package correctly installed /usr/lib/libseccomp.so.2. Give this binding the
+# normal Alpine SONAME as its fallback. The assertion deliberately breaks the
+# build if a future pyseccomp changes the line instead of silently publishing
+# another unconstrained image.
+RUN python -c "import pathlib,sysconfig; p=pathlib.Path(sysconfig.get_path('purelib'))/'pyseccomp.py'; s=p.read_text(); old='_libseccomp_path = ctypes.util.find_library(\"seccomp\")'; assert s.count(old)==1; p.write_text(s.replace(old, old+' or \"/usr/lib/libseccomp.so.2\"'))"
+
+# Importing the packages is not enough: the broken image imported ROM Hub and
+# only failed when the Plugins page asked pyseccomp to find its C library. Load
+# a real restrictive filter during the build so that exact failure cannot be
+# published again.
+RUN if [ "$TARGETARCH" != "arm" ]; then \
+      python -c "import rom_hub, pyseccomp; from rom_hub.sandbox import install; install()"; \
+    fi
 
 WORKDIR /app
 COPY romarr/ /app/romarr/

--- a/romarr/hub.py
+++ b/romarr/hub.py
@@ -172,7 +172,9 @@ def sandbox_state() -> tuple[bool, str]:
     try:
         return probe()
     except Exception as err:  # noqa: BLE001
-        return False, f"sandbox probe failed: {err.__class__.__name__}"
+        detail = str(err).strip()
+        suffix = f": {detail}" if detail else ""
+        return False, f"sandbox probe failed: {err.__class__.__name__}{suffix}"
 
 
 def _plugin_env() -> dict:

--- a/tests/test_docker_install.py
+++ b/tests/test_docker_install.py
@@ -158,6 +158,8 @@ def test_the_runtime_image_opens_alpines_versioned_seccomp_library():
     assert r'or \"/usr/lib/libseccomp.so.2\"' in body
     assert "from rom_hub.sandbox import install; install()" in body, (
         "the image does not prove that its seccomp filter can actually load")
+    assert '[ "$TARGETARCH" = "amd64" ]' in body, (
+        "the filter-load proof must run on the native smoke leg, not QEMU")
 
 
 def test_the_install_guide_exists_and_the_readme_sends_people_to_it():

--- a/tests/test_docker_install.py
+++ b/tests/test_docker_install.py
@@ -147,6 +147,19 @@ def test_the_healthcheck_asks_the_port_romarr_was_told_to_use():
     assert "ROMARR_PORT" in body.split("HEALTHCHECK", 1)[1]
 
 
+def test_the_runtime_image_opens_alpines_versioned_seccomp_library():
+    """Alpine has libseccomp.so.2 but ctypes looks for libseccomp.so.
+
+    The package was installed and the image still raised ``Unable to find
+    libseccomp``. The loader fallback is the difference between ROM Hub being
+    present and its plugins actually being confined.
+    """
+    body = DOCKERFILE.read_text(encoding="utf-8")
+    assert r'or \"/usr/lib/libseccomp.so.2\"' in body
+    assert "from rom_hub.sandbox import install; install()" in body, (
+        "the image does not prove that its seccomp filter can actually load")
+
+
 def test_the_install_guide_exists_and_the_readme_sends_people_to_it():
     assert INSTALL.is_file()
     assert "docs/INSTALL.md" in README.read_text(encoding="utf-8"), (

--- a/tests/test_plugin_sandbox.py
+++ b/tests/test_plugin_sandbox.py
@@ -77,6 +77,18 @@ def test_sandbox_state_reports_rather_than_raising(monkeypatch):
     assert isinstance(ok, bool) and isinstance(why, str) and why
 
 
+def test_a_probe_error_says_what_runtime_piece_is_missing(monkeypatch):
+    """A bare ``RuntimeError`` gave an Unraid operator nothing to fix."""
+    import rom_hub.sandbox
+
+    monkeypatch.setattr(rom_hub.sandbox, "probe",
+                        lambda: (_ for _ in ()).throw(
+                            RuntimeError("Unable to find libseccomp")))
+    ok, why = hub.sandbox_state()
+    assert ok is False
+    assert "RuntimeError: Unable to find libseccomp" in why
+
+
 def test_credentials_are_still_withheld_either_way(monkeypatch):
     """Confinement and the environment allowlist are separate boundaries, and
     turning one on must not quietly relax the other."""

--- a/tests/test_plugin_sandbox.py
+++ b/tests/test_plugin_sandbox.py
@@ -79,11 +79,16 @@ def test_sandbox_state_reports_rather_than_raising(monkeypatch):
 
 def test_a_probe_error_says_what_runtime_piece_is_missing(monkeypatch):
     """A bare ``RuntimeError`` gave an Unraid operator nothing to fix."""
-    import rom_hub.sandbox
+    import sys
+    import types
 
-    monkeypatch.setattr(rom_hub.sandbox, "probe",
-                        lambda: (_ for _ in ()).throw(
-                            RuntimeError("Unable to find libseccomp")))
+    package = types.ModuleType("rom_hub")
+    package.__path__ = []
+    sandbox = types.ModuleType("rom_hub.sandbox")
+    sandbox.probe = lambda: (_ for _ in ()).throw(
+        RuntimeError("Unable to find libseccomp"))
+    monkeypatch.setitem(sys.modules, "rom_hub", package)
+    monkeypatch.setitem(sys.modules, "rom_hub.sandbox", sandbox)
     ok, why = hub.sandbox_state()
     assert ok is False
     assert "RuntimeError: Unable to find libseccomp" in why


### PR DESCRIPTION
## What changed

- keep ROM Hub installed in the amd64/arm64 ROMarr image
- teach the Alpine pyseccomp binding to open the runtime package's versioned `libseccomp.so.2`
- fail the Docker build unless a real restrictive filter can be loaded
- make the GHCR smoke test load that filter instead of checking imports only
- expose the full sandbox probe error in the Plugins UI

## Root cause

The image contained both `rom_hub` and Alpine's `libseccomp` package, but `pyseccomp` uses `ctypes.util.find_library("seccomp")`. In Alpine's toolchain-free runtime stage that lookup returned `None` even though `/usr/lib/libseccomp.so.2` existed, raising `RuntimeError: Unable to find libseccomp`. ROMarr therefore reported and used the unconstrained fallback.

## Validation

- `20 passed` in the focused Docker/sandbox suite
- `1972 passed, 2 skipped`; the two local installer failures were caused by the Windows Store WSL stub and passed when rerun with Git Bash (`16 passed`)
- built the patched Alpine image on a real Docker host
- the container imports `rom_hub` and reports `seccomp filter available`
- after filter installation, `socket.socket()` is refused with `EPERM`
