### PR TITLE
Fix empty plugin catalogue in Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,6 +118,8 @@ jobs:
             || { echo "bsdtar missing"; exit 1; }
           docker exec smoke python -c "import requests, rom_hub; from rom_hub.sandbox import install; install()" \
             || { echo "a dependency did not install"; exit 1; }
+          docker exec smoke python -c "from pathlib import Path; from rom_hub.catalog_sources import load_all; c=load_all(Path('/tmp/hub-smoke')); print(f'{len(c.entries)} bundled plugins'); assert c.entries" \
+            || { echo "ROM Hub installed without its plugin catalogue"; exit 1; }
 
           echo "--- privileges were dropped ---"
           docker logs smoke 2>&1 | grep -q "starting as 1000:1000" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install --no-cache-dir --prefix=/install -r /tmp/requirements.txt
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" != "arm" ]; then \
       pip install --no-cache-dir --prefix=/install \
-        "rom-hub @ https://github.com/BlizzHacker/rom-hub/archive/7095cd14623f904e32bedc816a7559d93bf8a27f.tar.gz"; \
+        "rom-hub @ https://github.com/BlizzHacker/rom-hub/archive/8e46348783546ee03b00e2c933155ba60d29619d.tar.gz"; \
     fi
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install --no-cache-dir --prefix=/install -r /tmp/requirements.txt
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" != "arm" ]; then \
       pip install --no-cache-dir --prefix=/install \
-        "rom-hub @ https://github.com/BlizzHacker/rom-hub/archive/7e25e40c908eea2b023cc96a5546f6893b2822b1.tar.gz"; \
+        "rom-hub @ https://github.com/BlizzHacker/rom-hub/archive/7095cd14623f904e32bedc816a7559d93bf8a27f.tar.gz"; \
     fi
 
 

--- a/tests/test_docker_install.py
+++ b/tests/test_docker_install.py
@@ -162,6 +162,16 @@ def test_the_runtime_image_opens_alpines_versioned_seccomp_library():
         "the filter-load proof must run on the native smoke leg, not QEMU")
 
 
+def test_the_image_proves_rom_hubs_catalogue_is_not_empty():
+    """Importable ROM Hub is not useful when its wheel omitted plugins.json."""
+    workflow = (ROOT / ".github" / "workflows" / "docker.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "from rom_hub.catalog_sources import load_all" in workflow
+    assert "assert c.entries" in workflow
+    assert "ROM Hub installed without its plugin catalogue" in workflow
+
+
 def test_the_install_guide_exists_and_the_readme_sends_people_to_it():
     assert INSTALL.is_file()
     assert "docs/INSTALL.md" in README.read_text(encoding="utf-8"), (


### PR DESCRIPTION
## What changed

- pin Docker to the ROM Hub commit that packages its built-in catalogue
- make the image smoke test load the catalogue and fail unless it contains plugins
- pin that Docker contract in ROMarr's test suite

## Why

The confinement repair in #12 worked, but the pip-installed ROM Hub wheel omitted plugins.json. That produced the exact issue #10 report: a green confined banner and zero plugins.

## Verification

- python -m pytest -q tests/test_docker_install.py tests/test_plugin_sandbox.py — 21 passed
- upstream ROM Hub wheel inspection — 22 bundled plugins
- isolated upstream wheel install — 22 plugins, 1 of 1 catalogue reachable

Closes #10 once the merged image is published and its smoke test passes.