### PR TITLE
Fix Docker plugin installation failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -116,10 +116,14 @@ jobs:
           echo "--- the pieces that are easy to lose ---"
           docker exec smoke sh -c 'command -v bsdtar >/dev/null' \
             || { echo "bsdtar missing"; exit 1; }
+          docker exec smoke sh -c 'command -v git >/dev/null' \
+            || { echo "git missing; catalogue plugins cannot install"; exit 1; }
           docker exec smoke python -c "import requests, rom_hub; from rom_hub.sandbox import install; install()" \
             || { echo "a dependency did not install"; exit 1; }
           docker exec smoke python -c "from pathlib import Path; from rom_hub.catalog_sources import load_all; c=load_all(Path('/tmp/hub-smoke')); print(f'{len(c.entries)} bundled plugins'); assert c.entries" \
             || { echo "ROM Hub installed without its plugin catalogue"; exit 1; }
+          docker exec smoke sh -c 'ROM_HUB_HOME=/tmp/hub-install rom-hub plugin install archive-org' \
+            || { echo "bundled Archive.org plugin did not install"; exit 1; }
 
           echo "--- privileges were dropped ---"
           docker logs smoke 2>&1 | grep -q "starting as 1000:1000" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ ARG TARGETARCH
 # on a format it cannot open. Alpine's busybox `tar` is not a substitute and
 # is deliberately not accepted -- see romarr/library.py::_bsdtar.
 # libseccomp is the runtime half of the sandbox pyseccomp was built against.
-RUN apk add --no-cache su-exec tzdata libarchive-tools libseccomp
+# ROM Hub installs catalogue plugins from pinned repository refs, so git is a
+# runtime dependency rather than builder cargo.
+RUN apk add --no-cache su-exec tzdata libarchive-tools libseccomp git
 
 COPY --from=builder /install /usr/local
 

--- a/romarr/ui.py
+++ b/romarr/ui.py
@@ -735,7 +735,7 @@ RENDER.hub=async()=>{
 
   // State lives here rather than in the DOM: a filter that has to be read
   // back out of the markup drifts from what is actually displayed.
-  let q='', cap='', inst='';
+  let q='', cap='', inst='', actionError='';
 
   const load=async()=>{
     const qs=new URLSearchParams();
@@ -779,6 +779,7 @@ RENDER.hub=async()=>{
       +'<span class="chip'+(inst==='0'?' on':'')+'" data-inst="0">Available</span>'
       +chips+'</div>'
       +(d.error?'<div class="panel-note panel-warn">'+esc(d.error)+'</div>':'')
+      +(actionError?'<div class="panel-note panel-warn">'+esc(actionError)+'</div>':'')
       +'<div class="cat-scroll">'
       +(items.length?'<div class="pgrid">'+items.map(card).join('')+'</div>'
         :'<div class="empty-cat"><b>Nothing matches</b>'
@@ -827,10 +828,22 @@ RENDER.hub=async()=>{
       inst = inst===c.dataset.inst ? '' : c.dataset.inst; render(await load());});
 
     p.querySelectorAll('button[data-act]').forEach(b=>b.onclick=async()=>{
-      b.disabled=true; b.textContent='Working…';
-      await fetch('/api/v1/hub/plugin',{method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({slug:b.dataset.slug,action:b.dataset.act})});
+      const slug=b.dataset.slug, action=b.dataset.act;
+      b.disabled=true; b.textContent='Working…'; actionError='';
+      try{
+        const r=await fetch('/api/v1/hub/plugin',{method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({slug,action})});
+        let result={};
+        try{result=await r.json();}catch(_){result={};}
+        if(!r.ok||result.ok!==true){
+          actionError=result.error||result.reason
+            ||('Could not '+action+' '+slug+' (HTTP '+r.status+').');
+        }
+      }catch(e){
+        actionError='Could not '+action+' '+slug+': '
+          +(e&&e.message?e.message:'ROMarr did not answer.');
+      }
       render(await load());
     });
 

--- a/tests/test_docker_install.py
+++ b/tests/test_docker_install.py
@@ -172,6 +172,21 @@ def test_the_image_proves_rom_hubs_catalogue_is_not_empty():
     assert "ROM Hub installed without its plugin catalogue" in workflow
 
 
+def test_the_runtime_image_can_clone_a_bundled_plugin():
+    """The registry installer shells out to git; importing ROM Hub is not enough."""
+    body = DOCKERFILE.read_text(encoding="utf-8")
+    runtime = body.rsplit("\nFROM ", 1)[-1]
+    assert re.search(r"apk add --no-cache[^\n]*\bgit\b", runtime), (
+        "git is missing from the runtime image, so every registry install fails")
+
+    workflow = (ROOT / ".github" / "workflows" / "docker.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "command -v git" in workflow
+    assert "rom-hub plugin install archive-org" in workflow, (
+        "the image proves the catalogue exists but never proves a pinned plugin installs")
+
+
 def test_the_install_guide_exists_and_the_readme_sends_people_to_it():
     assert INSTALL.is_file()
     assert "docs/INSTALL.md" in README.read_text(encoding="utf-8"), (

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -72,3 +72,12 @@ def test_the_system_page_explains_and_builds_the_ggrequestz_webhook():
     assert "base.oninput" in html
     assert "copy.disabled=true" in html
     assert "request.auto_approve" in html
+
+
+def test_plugin_install_errors_are_displayed_in_the_hub():
+    """A failed install used to refresh the catalogue and erase the API error."""
+    html = page()
+    assert "let q='', cap='', inst='', actionError=''" in html
+    assert "if(!r.ok||result.ok!==true)" in html
+    assert "actionError=result.error||result.reason" in html
+    assert "esc(actionError)" in html


### PR DESCRIPTION
Fixes #15

## What changed
- install `git` in the final Docker image because ROM Hub installs catalogue entries from pinned repository refs
- make the Docker smoke test install the bundled Archive.org plugin, covering both the runtime dependency and the catalogue tag
- preserve and display `/api/v1/hub/plugin` errors instead of immediately refreshing them away
- handle non-JSON and network failures with a useful fallback message

The corresponding Archive.org v0.4.0 source is published at the tag expected by the bundled catalogue. Its review PR is https://github.com/BlizzHacker/rom-hub-archive-org/pull/2.

## Verification
- `python -m pytest -q tests/test_docker_install.py tests/test_ui.py tests/test_plugin_trust.py tests/test_plugin_sandbox.py` — 36 passed
- pinned ROM Hub install probe — `archive-org 0.4.0 enabled [census,importer,metadata,search,stream]`
- full suite — 1,976 passed, 1 skipped, 1 deselected; only two pre-existing shell syntax probes could not run because this Windows host resolves the Microsoft Store WSL placeholder as `bash.exe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin installation, enabling, and disabling now display clearer errors for network failures, invalid responses, and server-reported issues.
  * Error messages remain visible after the plugin catalogue refreshes.

* **Improvements**
  * Docker installations now include Git, enabling installation of bundled plugins from pinned repository sources.
  * Added verification that bundled plugins can be installed successfully in the runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->