### PR TITLE
Fix GG Requestz request delivery setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,34 @@ Download URLs are never returned to a client: Prowlarr's `downloadUrl` carries i
 API key, so releases are grabbed by the id issued with the search and the URL is
 resolved server-side.
 
+### GG Requestz
+
+GG Requestz pushes approved requests to ROMarr. It is not a `rom-hub webhook`
+command inside the ROMarr container. Open **System → GG Requestz requests** to
+build the exact setting, or configure this in the **GG Requestz container**:
+
+```env
+REQUEST_WEBHOOK_URL=http://romarr:6868/api/v1/webhook/ggrequestz?apikey=<ROMARR_API_KEY>
+```
+
+`http://romarr:6868` works when both containers share a Docker network. On
+Unraid or separate networks, replace it with ROMarr's LAN or HTTPS URL as seen
+from inside GG Requestz. Restart GG Requestz after changing its environment.
+
+`GGREQUESTZ_URL` goes the other direction: it only lets ROMarr show and ping the
+GG Requestz page. A green status there proves the page is reachable; it does
+not prove the outbound webhook is configured.
+
+GG Requestz 1.5 and newer dispatches when a request becomes **approved**, not
+when a pending request is first submitted. Enable `request.auto_approve` or
+approve the request manually. ROMarr answers an accepted request with HTTP 202;
+an invalid event or unknown platform receives HTTP 422 so GG Requestz records a
+real delivery failure instead of treating the request as sent.
+
+The finished webhook URL contains ROMarr's API key. Treat it like a password,
+keep it on a trusted Docker network or HTTPS, and do not paste it into public
+logs.
+
 ---
 
 ## Plugins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,10 @@ services:
       # QBITTORRENT_CATEGORY: romarr
       # NZBGET_CATEGORY: romarr
 
-      # Optional request front-end, shown on the System page.
+      # Optional request front-end, shown and pinged on the System page. This
+      # is NOT the request-delivery setting. In GG Requestz's own container set
+      # REQUEST_WEBHOOK_URL to the value built on ROMarr's System page, e.g.:
+      # http://romarr:6868/api/v1/webhook/ggrequestz?apikey=<ROMARR_API_KEY>
       # GGREQUESTZ_URL: http://ggrequestz:3000
 
       # Optional headless RetroArch stream server. ROMarr only ever reads from

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -412,6 +412,31 @@ ROMarr does tell you about this in the one case where it can be certain: if
 the stored library path does not exist but the one in the environment does, the
 status page says so and names the Settings page as the fix.
 
+### Connect GG Requestz
+
+Request delivery is configured on the **GG Requestz side**. ROMarr's
+`GGREQUESTZ_URL` only adds and checks the link shown on the System page; it does
+not tell GG Requestz where to send anything. Open **System → GG Requestz
+requests** in ROMarr to build the value, then add it to the GG Requestz
+container and restart that container:
+
+```env
+REQUEST_WEBHOOK_URL=http://romarr:6868/api/v1/webhook/ggrequestz?apikey=<ROMARR_API_KEY>
+```
+
+The hostname `romarr` works only when the containers share a Docker network.
+For Unraid or separate stacks, use the LAN address and published port, such as
+`http://192.168.1.20:6868`. The URL must work from inside the GG Requestz
+container, not merely from a browser.
+
+GG Requestz 1.5+ sends the event only after the request is approved. Turn on
+`request.auto_approve` if requests should flow immediately, or approve each one
+in GG Requestz. The receiver is ROMarr itself; the `rom-hub webhook` commands
+described for a standalone ROM Hub are not installed or needed in this image.
+
+The query parameter is a credential because GG Requestz cannot attach an API
+key header. Keep it private and use a trusted Docker network or HTTPS.
+
 ---
 
 ## Configuration reference

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -41,7 +41,7 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import time
 
@@ -112,7 +112,17 @@ DEFAULT_CATEGORY = "romarr"
 
 def redact_query_credentials(value: str) -> str:
     """Hide URL credentials while preserving a useful HTTP log line."""
-    return re.sub(r"(?i)([?&]apikey=)[^&\s\"]*", r"\1[REDACTED]", str(value))
+    def redact(match: re.Match) -> str:
+        marker, name, _ = match.groups()
+        if unquote_plus(name).casefold() == "apikey":
+            return f"{marker}{name}=[REDACTED]"
+        return match.group(0)
+
+    # Decode the parameter *name* for the decision, because parse_qs does too:
+    # `api%6bey=` authenticates and therefore has to be redacted just as the
+    # ordinary spelling is. Leave every non-credential parameter byte-for-byte
+    # intact so the access log remains useful.
+    return re.sub(r"([?&])([^=&\s\"]+)=([^&\s\"]*)", redact, str(value))
 
 
 def category_for(env: dict[str, str], client: str) -> str:

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -1197,6 +1197,7 @@ class ROMarr:
         """
         parsed = self.parse_request_webhook(body)
         if parsed is None:
+            log.warning("GG Requestz webhook rejected: not a game request")
             return {"ok": False, "error": "not a game request"}
         game, platform_name = parsed
 
@@ -1207,9 +1208,12 @@ class ROMarr:
             self.store.record(Event(kind="failed", game=game,
                                     platform=platform_name or "unknown",
                                     detail=f"unknown platform: {platform_name!r}"))
+            log.warning("GG Requestz webhook rejected: unknown platform %r "
+                        "for %r", platform_name, game)
             return {"ok": False, "error": f"unknown platform: {platform_name!r}",
                     "game": game}
 
+        log.info("GG Requestz webhook accepted: %r for %s", game, platform.slug)
         threading.Thread(target=self.request, args=(game, platform.slug),
                          daemon=True).start()
         return {"ok": True, "accepted": True, "game": game, "platform": platform.slug}
@@ -5327,7 +5331,14 @@ def make_handler(service: ROMarr):
                 existing = service.store.get_item("indexers", body.get("id"))                     if body.get("id") else None
                 return self._json(200, service.test_indexer(merge_secrets(dict(body), existing)))
             if route.path in ("/api/v1/webhook", "/api/v1/webhook/ggrequestz"):
-                return self._json(200, service.handle_request_webhook(body))
+                result = service.handle_request_webhook(body)
+                # GG Requestz treats every 2xx response as delivered and does
+                # not inspect the JSON body. Returning 200 with {ok:false}
+                # therefore made an unmapped platform disappear silently.
+                # 202 is truthful for the asynchronous happy path; 422 makes
+                # the sender log a rejected event and gives the operator a
+                # reason in our response and logs.
+                return self._json(202 if result.get("ok") else 422, result)
             if route.path == "/api/v1/command":
                 name = (body.get("name") or "").strip()
                 if not name:

--- a/romarr/app.py
+++ b/romarr/app.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import threading
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
@@ -107,6 +108,11 @@ VERSION = "0.8.0"
 # from everything else in a shared client -- the same reason Radarr and Sonarr
 # each use a category of their own.
 DEFAULT_CATEGORY = "romarr"
+
+
+def redact_query_credentials(value: str) -> str:
+    """Hide URL credentials while preserving a useful HTTP log line."""
+    return re.sub(r"(?i)([?&]apikey=)[^&\s\"]*", r"\1[REDACTED]", str(value))
 
 
 def category_for(env: dict[str, str], client: str) -> str:
@@ -4105,7 +4111,8 @@ def make_handler(service: ROMarr):
             try:
                 return handler()
             except Exception as exc:
-                log.exception("%s %s failed", self.command, self.path)
+                log.exception("%s %s failed", self.command,
+                              redact_query_credentials(self.path))
                 return self._json(500, {"error": f"{type(exc).__name__}: {exc}"})
 
         #: Paths that answer without a credential, and nothing else.
@@ -5416,7 +5423,12 @@ def make_handler(service: ROMarr):
             return self._json(404, {"error": "not found"})
 
         def log_message(self, fmt, *args):
-            log.info("%s %s", self.address_string(), fmt % args)
+            # BaseHTTPRequestHandler logs the complete request target. The
+            # GG Requestz credential has to live in that target because the
+            # sender cannot attach an authentication header, so redact it
+            # before it can reach either stdout or the in-app log ring.
+            message = redact_query_credentials(fmt % args)
+            log.info("%s %s", self.address_string(), message)
 
     return Handler
 

--- a/romarr/ui.py
+++ b/romarr/ui.py
@@ -2864,10 +2864,17 @@ const ggrequestzCard=g=>`<div class="card"><h3>GG Requestz requests</h3>
 const wireGGRequestz=()=>{
   const base=$('#ggr-base'), build=$('#ggr-build'), copy=$('#ggr-copy');
   const value=$('#ggr-value'); if(!base||!build||!copy||!value) return;
-  base.value=location.origin;
+  // Do not assume the browser-facing origin works from another container.
+  // `localhost` here would mean the GG Requestz container itself there.
+  base.value='';
+  base.oninput=()=>{
+    value.textContent=''; value.style.display='none'; copy.disabled=true;
+  };
   build.onclick=async()=>{
     build.disabled=true;
     try{
+      if(!base.value.trim()) throw new Error(
+        'Enter the ROMarr URL reachable from inside GG Requestz');
       const d=await j('/api/v1/system/apikey');
       if(!d.api_key) throw new Error('ROMarr did not return an API key');
       const target=new URL('/api/v1/webhook/ggrequestz',base.value.trim());

--- a/romarr/ui.py
+++ b/romarr/ui.py
@@ -2729,9 +2729,11 @@ RENDER.status=async()=>{
                   : (l.path_exists ? l.path : (l.path_hint||l.path)))).join('')
         : row('RomM',h.romm,h.romm_url)
           +row('ROM library',h.library,h.library?h.library_path:(h.library_path_hint||h.library_path))}
-      ${g.configured?row('GG Requestz',g.ok,g.url)
-        :`<tr><td>GG Requestz</td><td><span class="dot"></span>not configured</td>
-          <td style="color:var(--dim)">set GGREQUESTZ_URL to show the link</td></tr>`}
+      ${g.configured?row('GG Requestz page',g.ok,
+          g.url+' (reachability only; request delivery is configured below)')
+        :`<tr><td>GG Requestz page</td><td><span class="dot"></span>not configured</td>
+          <td style="color:var(--dim)">GGREQUESTZ_URL only adds and checks the
+          front-end link; it does not deliver requests</td></tr>`}
       ${h.stream_url
         ? row('Stream server',(h.play_routes||{}).stream>0,h.stream_url)
         : `<tr><td>Stream server</td><td><span class="dot"></span>not configured</td>
@@ -2746,6 +2748,7 @@ RENDER.status=async()=>{
            <td style="color:var(--dim)">set MOONLIGHT_HOST to a Wolf, Sunshine or
            Steam Headless machine</td></tr>`}
     </tbody></table></div>
+    ${ggrequestzCard(g)}
     ${playCard(h.play_routes||{})}
     ${moonlightCard(h.moonlight||{})}
     <div class="card"><h3>About</h3><div class="st">
@@ -2785,6 +2788,7 @@ RENDER.status=async()=>{
     <div class="row" style="flex-wrap:wrap;gap:8px" id="fe-row"></div>
     </div>`;
 
+  wireGGRequestz();
   wireMoonlight(h.moonlight||{});
 
   const msg=(ok,text)=>{const m=$('#bk-msg');
@@ -2825,6 +2829,60 @@ RENDER.status=async()=>{
   feRow.querySelectorAll('.fe-btn').forEach(b=>b.onclick=()=>
     save('/api/v1/frontend/export?format='+b.dataset.f,
          'romarr-'+b.dataset.f+'.export'));
+};
+
+// GG Requestz pushes to ROMarr; the reachability probe above is deliberately
+// labelled as the opposite direction. The API key is revealed only after a
+// deliberate click, just like Settings -> General, because the finished URL
+// is itself a credential and should not sit in the page by default.
+const ggrequestzCard=g=>`<div class="card"><h3>GG Requestz requests</h3>
+  <p class="help"><b>Configure this in GG Requestz, not ROM Hub.</b>
+  Set <code>REQUEST_WEBHOOK_URL</code> in the GG Requestz container to ROMarr's
+  authenticated receiver. <code>GGREQUESTZ_URL</code> in ROMarr only creates
+  the page link and reachability check above.</p>
+  <label>ROMarr URL as the GG Requestz container reaches it</label>
+  <input id="ggr-base" placeholder="http://romarr:6868">
+  <p class="help">On the same Docker network this is normally
+  <code>http://romarr:6868</code>. On Unraid or separate networks, use ROMarr's
+  LAN or HTTPS URL. The value must be reachable from inside GG Requestz.</p>
+  <div class="row" style="flex-wrap:wrap;gap:8px;align-items:center">
+    <button class="btn" id="ggr-build" type="button">Reveal setup value</button>
+    <button class="btn ghost" id="ggr-copy" type="button" disabled>Copy</button>
+  </div>
+  <pre id="ggr-value" style="display:none;font:12px/1.6 ui-monospace,Menlo,monospace;
+    color:var(--dim);white-space:pre-wrap;overflow-wrap:anywhere;background:var(--bg);
+    border:1px solid var(--line);border-radius:6px;padding:10px"></pre>
+  <p class="help">Restart GG Requestz after changing its environment. In GG
+  Requestz 1.5+, the webhook fires when a request becomes <b>approved</b>;
+  enable <code>request.auto_approve</code> or approve it manually. A successful
+  delivery now receives HTTP 202. Rejected payloads receive HTTP 422 and are
+  named in both applications' logs.</p>
+  <p class="help">Treat the finished URL like a password: it contains ROMarr's
+  API key. Keep it on a trusted Docker network or HTTPS and do not paste it in
+  public logs.</p></div>`;
+
+const wireGGRequestz=()=>{
+  const base=$('#ggr-base'), build=$('#ggr-build'), copy=$('#ggr-copy');
+  const value=$('#ggr-value'); if(!base||!build||!copy||!value) return;
+  base.value=location.origin;
+  build.onclick=async()=>{
+    build.disabled=true;
+    try{
+      const d=await j('/api/v1/system/apikey');
+      if(!d.api_key) throw new Error('ROMarr did not return an API key');
+      const target=new URL('/api/v1/webhook/ggrequestz',base.value.trim());
+      target.searchParams.set('apikey',d.api_key);
+      value.textContent='REQUEST_WEBHOOK_URL='+target.href;
+      value.style.display='block'; copy.disabled=false;
+    }catch(e){
+      value.textContent='Could not build the URL: '+(e.message||e);
+      value.style.display='block'; copy.disabled=true;
+    }finally{build.disabled=false;}
+  };
+  copy.onclick=async()=>{
+    try{await navigator.clipboard.writeText(value.textContent); toast('Copied');}
+    catch(_){toast('Copy failed — select the value manually');}
+  };
 };
 
 // The Moonlight host: what it is, what it proves, and the one step that is

--- a/tests/test_auth_http.py
+++ b/tests/test_auth_http.py
@@ -93,6 +93,54 @@ def test_writing_needs_a_key(server):
         assert code == 401, f"{method} {path} answered {code}"
 
 
+def test_ggrequestz_can_deliver_with_the_query_key(server):
+    """GG Requestz can configure a URL but cannot add an authentication header."""
+    base, service = server
+    received = []
+    called = threading.Event()
+
+    def request(game, platform):
+        received.append((game, platform))
+        called.set()
+
+    service.request = request
+    payload = {
+        "type": "game_request",
+        "title": "New Game Request: Chrono Trigger",
+        "data": {
+            "request_id": 42,
+            "game_title": "Chrono Trigger",
+            "platforms": ["Super Nintendo"],
+            "request_type": "game",
+        },
+    }
+    code, body, _ = get(
+        base + "/api/v1/webhook/ggrequestz?apikey=testkey",
+        method="POST", body=payload,
+    )
+
+    assert code == 202
+    assert json.loads(body)["accepted"] is True
+    assert called.wait(2)
+    assert received == [("Chrono Trigger", "snes")]
+
+
+def test_ggrequestz_is_told_when_romarr_rejects_the_event(server):
+    """The sender only checks HTTP status, so {ok:false} with 200 is a false success."""
+    base, _ = server
+    code, body, _ = get(
+        base + "/api/v1/webhook/ggrequestz?apikey=testkey",
+        method="POST",
+        body={"type": "game_request", "data": {
+            "game_title": "Halo", "platforms": ["Sega Nomad"]}},
+    )
+
+    assert code == 422
+    result = json.loads(body)
+    assert result["ok"] is False
+    assert "Sega Nomad" in result["error"]
+
+
 def test_a_401_says_how_to_authenticate(server):
     base, _ = server
     _, body, _ = get(base + "/api/v1/game")

--- a/tests/test_auth_http.py
+++ b/tests/test_auth_http.py
@@ -8,6 +8,7 @@ and unwired is exactly as open as no gate at all.
 from __future__ import annotations
 
 import json
+import logging
 import threading
 import urllib.error
 import urllib.request
@@ -139,6 +140,25 @@ def test_ggrequestz_is_told_when_romarr_rejects_the_event(server):
     result = json.loads(body)
     assert result["ok"] is False
     assert "Sega Nomad" in result["error"]
+
+
+def test_the_query_key_never_enters_the_access_log(server, caplog):
+    """The only auth GG Requestz can send is in a URL, which HTTP servers log."""
+    base, service = server
+    service.request = lambda *_: None
+    caplog.set_level(logging.INFO, logger="romarr.app")
+
+    code, _, _ = get(
+        base + "/api/v1/webhook/ggrequestz?source=ggr&apikey=testkey&retry=1",
+        method="POST",
+        body={"type": "game_request", "data": {
+            "game_title": "Contra", "platforms": ["NES"]}},
+    )
+
+    assert code == 202
+    assert "testkey" not in caplog.text
+    assert "apikey=[REDACTED]" in caplog.text
+    assert "source=ggr" in caplog.text and "retry=1" in caplog.text
 
 
 def test_a_401_says_how_to_authenticate(server):

--- a/tests/test_auth_http.py
+++ b/tests/test_auth_http.py
@@ -149,7 +149,7 @@ def test_the_query_key_never_enters_the_access_log(server, caplog):
     caplog.set_level(logging.INFO, logger="romarr.app")
 
     code, _, _ = get(
-        base + "/api/v1/webhook/ggrequestz?source=ggr&apikey=testkey&retry=1",
+        base + "/api/v1/webhook/ggrequestz?source=ggr&api%6Bey=testkey&retry=1",
         method="POST",
         body={"type": "game_request", "data": {
             "game_title": "Contra", "platforms": ["NES"]}},
@@ -157,7 +157,7 @@ def test_the_query_key_never_enters_the_access_log(server, caplog):
 
     assert code == 202
     assert "testkey" not in caplog.text
-    assert "apikey=[REDACTED]" in caplog.text
+    assert "api%6Bey=[REDACTED]" in caplog.text
     assert "source=ggr" in caplog.text and "retry=1" in caplog.text
 
 

--- a/tests/test_ggrequestz_docs.py
+++ b/tests/test_ggrequestz_docs.py
@@ -1,0 +1,26 @@
+"""The two settings point in opposite directions; keep the setup unambiguous."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_the_readme_documents_the_actual_ggrequestz_receiver():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "REQUEST_WEBHOOK_URL=http://romarr:6868/api/v1/webhook/ggrequestz" in readme
+    assert "GGREQUESTZ_URL` goes the other direction" in readme
+    assert "request.auto_approve" in readme
+
+
+def test_the_compose_file_does_not_claim_the_link_setting_delivers_requests():
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    assert "is NOT the request-delivery setting" in compose
+    assert "REQUEST_WEBHOOK_URL" in compose
+
+
+def test_unraid_and_standalone_rom_hub_are_covered_in_the_install_guide():
+    guide = (ROOT / "docs" / "INSTALL.md").read_text(encoding="utf-8")
+    assert "For Unraid or separate stacks" in guide
+    assert "rom-hub webhook" in guide
+    assert "not installed or needed in this image" in guide

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -59,3 +59,13 @@ def test_a_list_field_round_trips_through_the_form():
     html = page()
     assert "f.type === 'list'" in html
     assert "el.dataset.list ? el.value.split(',')" in html
+
+
+def test_the_system_page_explains_and_builds_the_ggrequestz_webhook():
+    html = page()
+    assert "GG Requestz page" in html
+    assert "reachability only; request delivery is configured below" in html
+    assert "REQUEST_WEBHOOK_URL=" in html
+    assert "new URL('/api/v1/webhook/ggrequestz'" in html
+    assert "target.searchParams.set('apikey',d.api_key)" in html
+    assert "request.auto_approve" in html

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -68,4 +68,7 @@ def test_the_system_page_explains_and_builds_the_ggrequestz_webhook():
     assert "REQUEST_WEBHOOK_URL=" in html
     assert "new URL('/api/v1/webhook/ggrequestz'" in html
     assert "target.searchParams.set('apikey',d.api_key)" in html
+    assert "base.value=''" in html
+    assert "base.oninput" in html
+    assert "copy.disabled=true" in html
     assert "request.auto_approve" in html


### PR DESCRIPTION
Fixes #18

## What was wrong

`GGREQUESTZ_URL` only lets ROMarr display and ping the GG Requestz page. It does not configure GG Requestz's outbound request webhook, but the System page showed a green `OK` without explaining that distinction. The documentation never gave the required sender-side setting. Rejected events also returned HTTP 200 with `{ok:false}`, and GG Requestz only checks the status code, so it recorded those as delivered.

## What changed

- add a System-page setup card that builds the exact authenticated `REQUEST_WEBHOOK_URL`
- clearly label the existing GG Requestz probe as page reachability only
- document same-network Docker, Unraid/separate-network, restart, approval, and credential requirements
- return HTTP 202 for accepted asynchronous requests and HTTP 422 for invalid/unmapped requests
- log accepted and rejected webhook events without logging the credential
- exercise the current GG Requestz payload over a real authenticated HTTP socket

ROM Hub's misleading published CLI instructions are corrected separately in https://github.com/BlizzHacker/rom-hub/pull/46.

## Verification

- focused integration/UI/auth/docs suite: 81 passed
- full ROMarr suite: 1,980 passed, 1 skipped, 1 deselected
- the remaining two host-only Bash checks cannot run because this Windows host resolves the unconfigured Microsoft Store WSL launcher as `bash.exe`
- generated UI JavaScript passes `node --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GG Requestz webhook integration guidance and setup instructions.
  * Added a System Status setup card with reachability details and authenticated webhook URL generation.
  * Webhook requests now return clear acceptance or rejection responses.

* **Bug Fixes**
  * Improved handling and logging for rejected payloads and unknown platforms.
  * Prevented API keys from appearing in request logs.
  * Clarified Docker networking, approval behavior, and API-key handling.
  * Webhook setup now requires an explicitly reachable ROMarr address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->